### PR TITLE
Remove deprecated dynamic exception specification

### DIFF
--- a/src/clasp_options.cpp
+++ b/src/clasp_options.cpp
@@ -93,7 +93,7 @@ static const char* findKey(const Span<KV>& map, int x) {
 
 struct ArgString {
 	ArgString(const char* x) : in(x), skip(0) { }
-	~ArgString() throw (std::logic_error) { POTASSCO_ASSERT(!ok() || !*in || off(), "Unused argument!"); }
+	~ArgString() { POTASSCO_ASSERT(!ok() || !*in || off(), "Unused argument!"); }
 	bool ok()       const { return in != 0; }
 	bool off()      const { return ok() && stringTo(in, Potassco::off); }
 	bool empty()    const { return ok() && !*in; }


### PR DESCRIPTION
gcc 7.1.1 says:

```
/build/clasp/src/clasp-3.3.0/src/clasp_options.cpp:96:15: warning: dynamic exception specifications are deprec
ated in C++11 [-Wdeprecated]
  ~ArgString() throw (std::logic_error) { POTASSCO_ASSERT(!ok() || !*in || off(), "Unused argument!"); }
               ^~~~~
```

This pull request fixes that.