### PR TITLE
buildsys: disable class-memaccess warning

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -141,6 +141,7 @@ set_target_properties(libclasp PROPERTIES VERSION ${PROJECT_VERSION})
 set_target_properties(libclasp PROPERTIES
 	OUTPUT_NAME clasp
 	FOLDER lib)
+target_compile_options(libclasp PUBLIC $<$<CXX_COMPILER_ID:GNU>:-Wno-class-memaccess>)
 
 # installation
 if (CLASP_INSTALL_LIB)


### PR DESCRIPTION
The pod vector triggers this GCC 8 warning. However, this behavior is intended. Therefore, disable this warning as to make the compilation less noisy.