### PR TITLE
Fix issue 69

### DIFF
--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -98,8 +98,12 @@ struct Solver::Dirty {
 	}
 	void cleanup(Watches& watches, DecisionLevels& levels) {
 		InSet inCons = { &cons };
+		const uint32 maxId = (uint32)watches.size();
 		for (DirtyList::left_iterator it = dirty.left_begin(), end = dirty.left_end(); it != end; ++it) {
-			WatchList& wl = watches[it->id()];
+			uint32 id = it->id();
+			if (id >= maxId)
+				continue;
+			WatchList& wl = watches[id];
 			if (wl.left_size() && test_and_clear(wl.left_begin()->head)) { wl.shrink_left(std::remove_if(wl.left_begin(), wl.left_end(), inCons)); }
 			if (wl.right_size()&& test_and_clear(wl.right_begin()->con)) { wl.shrink_right(std::remove_if(wl.right_begin(), wl.right_end(), inCons)); }
 		}

--- a/src/unfounded_check.cpp
+++ b/src/unfounded_check.cpp
@@ -577,7 +577,7 @@ bool DefaultUnfoundedCheck::assertAtom(Literal a, UfsType t) {
 		computeReason(t);
 	}
 	activeClause_[0] = ~a;
-	bool noClause = solver_->isTrue(a) || strategy_ == no_reason || strategy_ == only_reason || (strategy_ == shared_reason && activeClause_.size() > 3);
+	bool noClause = solver_->isTrue(a) || strategy_ == no_reason || strategy_ == only_reason || (strategy_ == shared_reason && activeClause_.size() > 3 && !info_.tagged());
 	if (noClause) {
 		if (!solver_->force(~a, this))  { return false; }
 		if (strategy_ == only_reason)   { reasons_[a.var()-1].assign(activeClause_.begin()+1, activeClause_.end()); }
@@ -596,6 +596,7 @@ void DefaultUnfoundedCheck::createLoopFormula() {
 		ante = ClauseCreator::create(*solver_, activeClause_, ClauseCreator::clause_no_prepare, info_).local;
 	}
 	else {
+		assert(!info_.tagged());
 		ante = LoopFormula::newLoopFormula(*solver_
 			, ClauseRep::prepared(&activeClause_[0], (uint32)activeClause_.size(), info_)
 			, &loopAtoms_[0], (uint32)loopAtoms_.size());


### PR DESCRIPTION
There are at least two natural alternatives to this "quick-and-dirty" fix:

- Treat LoopFormula as a clause by deriving it from ClauseHead instead of Constraint.
- Move `ClauseHead::tagged()` and `ClauseHead::strengthen()` up to the Constraint interface so that `Solver::removeConditional()` and `Solver::strengthenConfitional()` can be applied over all learnt constraints.

Both alternatives would require quite some effort and it's unclear whether there would be any real benefit.
