### PR TITLE
refine overflow checks in LogicProgram

### DIFF
--- a/src/logic_program_types.cpp
+++ b/src/logic_program_types.cpp
@@ -400,8 +400,8 @@ bool SccChecker::onNode(PrgNode* n, NodeType t, Call& c, uint32 data) {
 /////////////////////////////////////////////////////////////////////////////////////////
 PrgNode::PrgNode(uint32 id, bool checkScc)
 	: litId_(noLit), noScc_(uint32(!checkScc)), id_(id), val_(value_free), eq_(0), seen_(0) {
+	POTASSCO_CHECK(id < noNode, EOVERFLOW, "Id out of range");
 	static_assert(sizeof(PrgNode) == sizeof(uint64), "Unsupported Alignment");
-	POTASSCO_CHECK(id_ == id, EOVERFLOW, "Id out of range");
 }
 /////////////////////////////////////////////////////////////////////////////////////////
 // class PrgHead
@@ -545,6 +545,7 @@ PrgAtom::PrgAtom(uint32 id, bool checkScc)
 
 void PrgAtom::setEqGoal(Literal x) {
 	if (eq()) {
+		POTASSCO_CHECK(!x.sign() || x.var() < noScc, EOVERFLOW, "Id out of range");
 		data_ = x.sign() ? x.var() : noScc;
 	}
 }


### PR DESCRIPTION
The logic program class accepts atoms with ids less than 2^28 and during preprocessing this can drop to less than 2^27 in some cases.

The less than 2^27 is a bit annoying but should not matter much in practice. One should rather find a better way to encode problems with such big groundings. :smile: 