### PR TITLE
clingo: Add support for propagator undo mode.

### DIFF
--- a/clasp/clingo.h
+++ b/clasp/clingo.h
@@ -98,14 +98,19 @@ public:
 	//! Sets the type of checks to enable during solving.
 	/*!
 	 * \param checkMode A set of ClingoPropagatorCheck_t::Type values.
-	 * \param undoMode  The undo mode to use during solving.
+	 */
+	void enableClingoPropagatorCheck(CheckType checkMode);
+
+	//! Sets the undo mode to use when checks are enabled.
+	/*!
+	 * \param undoMode The undo mode to use.
 	 *
 	 * \note By default, AbstractPropagator::undo() is only called for levels on which
 	 *       at least one watched literal has been assigned. However, if undoMode is set
 	 *       to "Always", AbstractPropagator::undo() is also called for levels L with an
 	 *       empty change list if AbstractPropagator::check() has been called on L.
 	 */
-	void enableClingoPropagatorCheck(CheckType checkMode, UndoType undoMode = UndoType::Default);
+	void enableClingoPropagatorUndo(UndoType undoMode);
 
 	void enableHistory(bool b);
 

--- a/clasp/clingo.h
+++ b/clasp/clingo.h
@@ -61,6 +61,14 @@ struct ClingoPropagatorCheck_t {
 	};
 };
 
+//! Supported undo modes for clingo propagators.
+struct ClingoPropagatorUndo_t {
+	enum Type {
+		Default  = 0u, //!< Call AbstractPropagator::undo() only on levels with non-empty changelist.
+		Always   = 1u  //!< Call AbstractPropagator::undo() on all levels that have been propagated or checked.
+	};
+};
+
 //! Initialization adaptor for a Potassco::AbstractPropagator.
 /*!
  * The class provides a function for registering watches for the propagator.
@@ -70,6 +78,7 @@ struct ClingoPropagatorCheck_t {
 class ClingoPropagatorInit : public ClaspConfig::Configurator {
 public:
 	typedef ClingoPropagatorCheck_t::Type CheckType;
+	typedef ClingoPropagatorUndo_t::Type  UndoType;
 	//! Creates a new adaptor.
 	/*!
 	 * \param cb The (theory) propagator that should be added to solvers.
@@ -89,8 +98,14 @@ public:
 	//! Sets the type of checks to enable during solving.
 	/*!
 	 * \param checkMode A set of ClingoPropagatorCheck_t::Type values.
+	 * \param undoMode  The undo mode to use during solving.
+	 *
+	 * \note By default, AbstractPropagator::undo() is only called for levels on which
+	 *       at least one watched literal has been assigned. However, if undoMode is set
+	 *       to "Always", AbstractPropagator::undo() is also called for levels L with an
+	 *       empty change list if AbstractPropagator::check() has been called on L.
 	 */
-	void enableClingoPropagatorCheck(CheckType checkMode);
+	void enableClingoPropagatorCheck(CheckType checkMode, UndoType undoMode = UndoType::Default);
 
 	void enableHistory(bool b);
 
@@ -112,6 +127,7 @@ public:
 	Potassco::AbstractPropagator* propagator() const { return prop_; }
 	ClingoPropagatorLock*         lock()       const { return lock_; }
 	CheckType                     checkMode()  const { return check_; }
+	UndoType                      undoMode()   const { return undo_; }
 
 	uint32 init(uint32 lastStep, Potassco::AbstractSolver& s);
 private:
@@ -137,6 +153,7 @@ private:
 	ChangeList changes_;
 	uint32     step_;
 	CheckType  check_;
+	UndoType   undo_;
 };
 
 //! Adaptor for a Potassco::AbstractPropagator.

--- a/src/clingo.cpp
+++ b/src/clingo.cpp
@@ -231,6 +231,13 @@ void ClingoPropagator::undoLevel(Solver& s) {
 	POTASSCO_REQUIRE(s.decisionLevel() == level_, "Invalid undo");
 	uint32 beg = undo_.back();
 	undo_.pop_back();
+
+	if (test_bit(beg, CHECK_BIT) && call_->undoMode() == ClingoPropagatorUndo_t::Always) {
+		assert(beg >= prop_);
+		Potassco::LitSpan change = Potassco::toSpan<Potassco::Lit_t>();
+		ScopedLock(call_->lock(), call_->propagator(), Inc(epoch_))->undo(Control(*this, s), change);
+	}
+
 	if (prop_ > beg) {
 		Potassco::LitSpan change = Potassco::toSpan(&trail_[0] + beg, prop_ - beg);
 		ScopedLock(call_->lock(), call_->propagator(), Inc(epoch_))->undo(Control(*this, s), change);
@@ -417,7 +424,7 @@ struct ClingoPropagatorInit::History : POTASSCO_EXT_NS::unordered_map<Potassco::
 };
 
 ClingoPropagatorInit::ClingoPropagatorInit(Potassco::AbstractPropagator& cb, ClingoPropagatorLock* lock, CheckType m)
-	: prop_(&cb), lock_(lock), history_(0), step_(1), check_(m) {
+	: prop_(&cb), lock_(lock), history_(0), step_(1), check_(m), undo_(ClingoPropagatorUndo_t::Default) {
 }
 ClingoPropagatorInit::~ClingoPropagatorInit()         { delete history_; }
 bool ClingoPropagatorInit::applyConfig(Solver& s)     { return s.addPost(new ClingoPropagator(this)); }
@@ -500,8 +507,9 @@ uint32 ClingoPropagatorInit::init(uint32 lastStep, Potassco::AbstractSolver& s) 
 	return step_;
 }
 
-void ClingoPropagatorInit::enableClingoPropagatorCheck(CheckType checkMode) {
+void ClingoPropagatorInit::enableClingoPropagatorCheck(CheckType checkMode, UndoType undoMode) {
 	check_ = checkMode;
+	undo_  = undoMode;
 }
 
 void ClingoPropagatorInit::enableHistory(bool b) {

--- a/src/clingo.cpp
+++ b/src/clingo.cpp
@@ -507,9 +507,12 @@ uint32 ClingoPropagatorInit::init(uint32 lastStep, Potassco::AbstractSolver& s) 
 	return step_;
 }
 
-void ClingoPropagatorInit::enableClingoPropagatorCheck(CheckType checkMode, UndoType undoMode) {
+void ClingoPropagatorInit::enableClingoPropagatorCheck(CheckType checkMode) {
 	check_ = checkMode;
-	undo_  = undoMode;
+}
+
+void ClingoPropagatorInit::enableClingoPropagatorUndo(UndoType undoMode) {
+	undo_ = undoMode;
 }
 
 void ClingoPropagatorInit::enableHistory(bool b) {

--- a/tests/facade_test.cpp
+++ b/tests/facade_test.cpp
@@ -2215,12 +2215,12 @@ TEST_CASE("Clingo propagator", "[facade][propagator]") {
 		}
 		SECTION("test check is called only once per fixpoint") {
 			int expectedUndos = 0;
+			pp.enableClingoPropagatorCheck(ClingoPropagatorCheck_t::Fixpoint);
 			SECTION("fixpoint default undo") {
-				pp.enableClingoPropagatorCheck(ClingoPropagatorCheck_t::Fixpoint);
 				expectedUndos = 0;
 			}
 			SECTION("fixpoint always undo") {
-				pp.enableClingoPropagatorCheck(ClingoPropagatorCheck_t::Fixpoint, ClingoPropagatorUndo_t::Always);
+				pp.enableClingoPropagatorUndo(ClingoPropagatorUndo_t::Always);
 				expectedUndos = 1;
 			}
 			libclasp.prepare();
@@ -2241,12 +2241,12 @@ TEST_CASE("Clingo propagator", "[facade][propagator]") {
 		}
 		SECTION("with mode total check is called once on total") {
 			int expectedUndos = 0;
+			pp.enableClingoPropagatorCheck(ClingoPropagatorCheck_t::Total);
 			SECTION("total default undo") {
-				pp.enableClingoPropagatorCheck(ClingoPropagatorCheck_t::Total);
 				expectedUndos = 0;
 			}
 			SECTION("total always undo") {
-				pp.enableClingoPropagatorCheck(ClingoPropagatorCheck_t::Total, ClingoPropagatorUndo_t::Always);
+				pp.enableClingoPropagatorUndo(ClingoPropagatorUndo_t::Always);
 				expectedUndos = 1;
 			}
 			libclasp.solve();


### PR DESCRIPTION
* Add support for new clingo propagator undo mode "Always". If set, AbstractPropagator::undo() is called for all decision levels L on which AbstractPropagator::check() was called even if no watched literal was assigned on L.

* NOTE: For now, undo mode "Always" does not distinguish "Total" from "Fixpoint" checks.

@rkaminsk Please have a look and let me know whether you think this would work for your use case(s).