### PR TITLE
mutex.h: Update for MSC 1938 compat

### DIFF
--- a/clasp/mt/mutex.h
+++ b/clasp/mt/mutex.h
@@ -39,8 +39,9 @@ struct condition_variable : private std::condition_variable {
 	using base_type::notify_one;
 	using base_type::notify_all;
 	using base_type::wait;
+#if _MSC_VER < 1938
 	using base_type::native_handle;
-
+#endif
 	inline bool wait_for(unique_lock<mutex>& lock, double timeInSecs) {
 		return base_type::wait_for(lock, std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::duration<double>(timeInSecs)))
 			== std::cv_status::no_timeout;


### PR DESCRIPTION
MSC 1938 removes `native_handle` from the API.
Remove reference in mutex.h