### PR TITLE
ensure clasp and potassco install lib have the same value

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,7 @@ else()
 		message(STATUS "Potassco is not installed - using local copy")
 	endif()
 	set(LIB_POTASSCO_BUILD_APP       ${CLASP_BUILD_APP}   CACHE BOOL "")
-	set(LIB_POTASSCO_INSTALL_LIB     ${CLASP_INSTALL_LIB} CACHE BOOL "")
+	set(LIB_POTASSCO_INSTALL_LIB     ${CLASP_INSTALL_LIB} CACHE BOOL "" FORCE)
 	add_subdirectory(libpotassco)
 endif()
 


### PR DESCRIPTION
When reconfiguring the CLASP_INSTALL_LIB the LIB_POTASSCO_INSTALL_LIB does not change if it is already in the cache. This behavior can be changed by adding FORCE to the set command. What do you think? Should we also add it to the line above?