### PR TITLE
Add reified output support to --pre option.

### DIFF
--- a/clasp/cli/clasp_app.h
+++ b/clasp/cli/clasp_app.h
@@ -103,7 +103,7 @@ private:
 struct ClaspAppOptions {
     static constexpr uint8_t q_def = UINT8_MAX;
     enum OutputFormat { out_def = 0, out_comp = 1, out_json = 2, out_none = 3 };
-    enum PreFormat : uint8_t { pre_no, pre_aspif, pre_smodels, pre_reify };
+    enum PreFormat { pre_no, pre_aspif, pre_smodels, pre_reify };
     static constexpr bool isTextOutput(OutputFormat f) { return f == out_def || f == out_comp; }
     using LogOptions = LemmaLogger::Options;
     using StringSeq  = std::vector<std::string>;
@@ -123,11 +123,11 @@ struct ClaspAppOptions {
     LogOptions   lemma;                            // options for lemma logging
     uint8_t      quiet[3] = {q_def, q_def, q_def}; // configure printing of models, optimization values, and call steps
     PreFormat    pre{};                            // run preprocessor and exit
-    char         ifs        = ' ';                 // output field separator
-    bool         hideAux    = false;               // output aux atoms?
-    bool         printPort  = false;               // print portfolio and exit
-    bool         color      = {true};              // colorize output?
-    ReifyFlag    reifyFlags = {};                  // reification flags
+    ReifyFlag    reifyFlags{};                     // reification flags
+    char         ifs       = ' ';                  // output field separator
+    bool         hideAux   = false;                // output aux atoms?
+    bool         printPort = false;                // print portfolio and exit
+    bool         color     = {true};               // colorize output?
 };
 /////////////////////////////////////////////////////////////////////////////////////////
 // clasp application base

--- a/clasp/cli/clasp_app.h
+++ b/clasp/cli/clasp_app.h
@@ -103,28 +103,31 @@ private:
 struct ClaspAppOptions {
     static constexpr uint8_t q_def = UINT8_MAX;
     enum OutputFormat { out_def = 0, out_comp = 1, out_json = 2, out_none = 3 };
+    enum PreFormat : uint8_t { pre_no, pre_aspif, pre_smodels, pre_reify };
     static constexpr bool isTextOutput(OutputFormat f) { return f == out_def || f == out_comp; }
     using LogOptions = LemmaLogger::Options;
     using StringSeq  = std::vector<std::string>;
     using CatAtom    = TextOutput::CatAtom;
+    using ReifyFlag  = Asp::ReifyFlag;
     bool         apply(std::string_view, std::string_view);
     void         initOptions(Potassco::ProgramOptions::OptionContext& root);
     bool         validateOptions(const Potassco::ProgramOptions::ParsedOptions& parsed);
-    StringSeq    input;                             // list of input files - only first used!
-    std::string  lemmaLog;                          // optional file name for writing learnt lemmas
-    std::string  lemmaIn;                           // optional file name for reading learnt lemmas
-    std::string  hccOut;                            // optional file name for writing scc programs
-    CatAtom      outAtom;                           // optional format string for atoms
-    std::string  colString;                         // optional color style string
-    OutputFormat outf    = out_def;                 // output format
-    int          compute = 0;                       // force literal `compute` to true
-    LogOptions   lemma;                             // options for lemma logging
-    uint8_t      quiet[3]  = {q_def, q_def, q_def}; // configure printing of models, optimization values, and call steps
-    int8_t       pre       = 0;                     // run preprocessor and exit
-    char         ifs       = ' ';                   // output field separator
-    bool         hideAux   = false;                 // output aux atoms?
-    bool         printPort = false;                 // print portfolio and exit
-    bool         color     = {true};                // colorize output?
+    StringSeq    input;                            // list of input files - only first used!
+    std::string  lemmaLog;                         // optional file name for writing learnt lemmas
+    std::string  lemmaIn;                          // optional file name for reading learnt lemmas
+    std::string  hccOut;                           // optional file name for writing scc programs
+    CatAtom      outAtom;                          // optional format string for atoms
+    std::string  colString;                        // optional color style string
+    OutputFormat outf    = out_def;                // output format
+    int          compute = 0;                      // force literal `compute` to true
+    LogOptions   lemma;                            // options for lemma logging
+    uint8_t      quiet[3] = {q_def, q_def, q_def}; // configure printing of models, optimization values, and call steps
+    PreFormat    pre{};                            // run preprocessor and exit
+    char         ifs        = ' ';                 // output field separator
+    bool         hideAux    = false;               // output aux atoms?
+    bool         printPort  = false;               // print portfolio and exit
+    bool         color      = {true};              // colorize output?
+    ReifyFlag    reifyFlags = {};                  // reification flags
 };
 /////////////////////////////////////////////////////////////////////////////////////////
 // clasp application base

--- a/clasp/parser.h
+++ b/clasp/parser.h
@@ -115,8 +115,8 @@ enum class ReifyFlag : uint8_t {
 };
 POTASSCO_ENABLE_BIT_OPS(ReifyFlag);
 void write(LogicProgram& prg, std::ostream& os);
-void writeSmodels(LogicProgram& prg, std::ostream& os);
 void writeAspif(LogicProgram& prg, std::ostream& os);
+void writeSmodels(LogicProgram& prg, std::ostream& os);
 void writeReified(LogicProgram& prg, std::ostream& os, ReifyFlag flags);
 } // namespace Asp
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/clasp/parser.h
+++ b/clasp/parser.h
@@ -100,9 +100,6 @@ class AspParser final : public ProgramParser {
 public:
     static bool accept(char c);
     explicit AspParser(Asp::LogicProgram& prg);
-    enum Format { format_smodels = -1, format_aspif = 1 };
-    static void write(Asp::LogicProgram& prg, std::ostream& os);
-    static void write(Asp::LogicProgram& prg, std::ostream& os, Format f);
 
 private:
     StrategyType* doAccept(std::istream& str, const ParserOptions& o) override;
@@ -111,6 +108,17 @@ private:
     std::unique_ptr<StrategyType>              in_;
     std::unique_ptr<Potassco::AbstractProgram> out_;
 };
+namespace Asp {
+enum class ReifyFlag : uint8_t {
+    reify_scc  = 1u,
+    reify_step = 2u,
+};
+POTASSCO_ENABLE_BIT_OPS(ReifyFlag);
+void write(LogicProgram& prg, std::ostream& os);
+void writeSmodels(LogicProgram& prg, std::ostream& os);
+void writeAspif(LogicProgram& prg, std::ostream& os);
+void writeReified(LogicProgram& prg, std::ostream& os, ReifyFlag flags);
+} // namespace Asp
 /////////////////////////////////////////////////////////////////////////////////////////
 // SAT parsing
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/clasp_app.cpp
+++ b/src/clasp_app.cpp
@@ -81,9 +81,15 @@ void ClaspAppOptions::initOptions(Potassco::ProgramOptions::OptionContext& root)
          "        <mod> : print {0=all|1=last|2=no} models\n"                                    //
          "        <cost>: print {0=all|1=last|2=no} optimize values [<mod>]\n"                   //
          "        <call>: print {0=all|1=last|2=no} call steps      [2]")                        //
-        ("pre", value(action).arg("<fmt>").implicit("aspif"),                                    //
-         "Print simplified program and exit\n"                                                   //
-         "      %A: Set output format to {aspif|smodels} (implicit: %I)")                        //
+        ("preprocess", value(action).arg("<fmt>[,<opt>...]").implicit("aspif"),                  //
+         "Print simplified program and exit (Implicit: aspif)\n"                                 //
+         "      <fmt> : Set output format to {aspif|smodels|reify}\n"                            //
+         "        aspif  : Print program in ASP intermediate format\n"                           //
+         "        smodels: Print program in smodels format\n"                                    //
+         "        reify  : Print program as reified facts\n"                                     //
+         "      <opt> : Reifier options {steps|sccs}\n"                                          //
+         "        steps : Add step numbers\n"                                                    //
+         "        sccs  : Calculate SCCs")                                                       //
         ("@1,outf", storeTo(outf).arg("<fmt>").defaultsTo("text", true),                         //
          "Use {text|competition|json|no} output [%D]")                                           //
         ("@1!,out-color", value(action).defaultsTo("auto", true),                                //
@@ -123,7 +129,7 @@ bool ClaspAppOptions::apply(std::string_view name, std::string_view value) {
     else if (name == "lemma-out-dom"sv) {
         return (lemma.domOut = eqIgnoreCase(value, "output"sv)) == true || eqIgnoreCase(value, "input"sv);
     }
-    else if (name == "pre"sv && Parse::ok(extract(value, pre))) {
+    else if (name == "preprocess"sv && Parse::ok(extract(value, pre))) {
         if (pre == pre_reify) {
             while (Parse::matchOpt(value, ',')) {
                 if (auto key = "sccs"sv; eqIgnoreCase(value, key, key.size())) {
@@ -275,7 +281,7 @@ void ClaspAppBase::validateOptions(const Potassco::ProgramOptions::OptionContext
                            (not Clasp::contains(app.input, app.lemmaLog) && app.lemmaIn != app.lemmaLog),
                        std::errc::file_exists, "'lemma-out': cowardly refusing to overwrite input file");
         POTASSCO_CHECK(not app.pre || pt == ProblemType::asp, std::errc::operation_not_supported,
-                       "Option '--pre' only supported for ASP");
+                       "Option '--preprocess' only supported for ASP");
     }
     catch (const Potassco::RuntimeError& error) {
         throw Potassco::ProgramOptions::Error(std::string(error.message()));
@@ -607,7 +613,7 @@ void ClaspAppBase::handlePrepareEvent(ClaspFacade& clasp) {
                 case ClaspAppOptions::pre_aspif: Asp::writeAspif(*asp, std::cout); break;
                 case ClaspAppOptions::pre_smodels:
                     if (const char* err; not asp->supportsSmodels(&err)) {
-                        fail(exit_error, "Option '--pre': unsupported input format!",
+                        fail(exit_error, "Option '--preprocess': unsupported input format!",
                              std::string(err).append(
                                  " directive not supported!\nTry '--pre=aspif' to print in 'aspif' format"));
                     }
@@ -617,7 +623,7 @@ void ClaspAppBase::handlePrepareEvent(ClaspFacade& clasp) {
             }
         }
         else {
-            fail(exit_error, "Option '--pre': unsupported input format!");
+            fail(exit_error, "Option '--preprocess': unsupported input format!");
         }
     }
     else {

--- a/src/clasp_app.cpp
+++ b/src/clasp_app.cpp
@@ -67,6 +67,8 @@ inline bool              isStdOut(const std::string& out) { return out == "-" ||
 namespace Cli {
 POTASSCO_SET_ENUM_ENTRIES(ClaspAppOptions::OutputFormat, {out_def, "text"sv}, {out_comp, "competition"sv},
                           {out_json, "json"sv}, {out_none, "no"sv});
+POTASSCO_SET_ENUM_ENTRIES(ClaspAppOptions::PreFormat, {pre_aspif, "aspif"sv}, {pre_smodels, "smodels"sv},
+                          {pre_reify, "reify"sv});
 void ClaspAppOptions::initOptions(Potassco::ProgramOptions::OptionContext& root) {
     using namespace Potassco::ProgramOptions;
     OptionGroup basic("Basic Options");
@@ -106,8 +108,8 @@ bool ClaspAppOptions::apply(std::string_view name, std::string_view value) {
     using Potassco::extract;
     using Potassco::Parse::eqIgnoreCase;
     using namespace std::literals;
+    namespace Parse = Potassco::Parse;
     if (name == "quiet"sv) {
-        namespace Parse = Potassco::Parse;
         std::string_view in(value);
         uint32_t         q[3]    = {};
         auto             parsed  = 0u;
@@ -121,15 +123,23 @@ bool ClaspAppOptions::apply(std::string_view name, std::string_view value) {
     else if (name == "lemma-out-dom"sv) {
         return (lemma.domOut = eqIgnoreCase(value, "output"sv)) == true || eqIgnoreCase(value, "input"sv);
     }
-    else if (name == "pre"sv) {
-        if (eqIgnoreCase(value, "aspif"sv)) {
-            pre = static_cast<int8_t>(AspParser::format_aspif);
-            return true;
+    else if (name == "pre"sv && Parse::ok(extract(value, pre))) {
+        if (pre == pre_reify) {
+            while (Parse::matchOpt(value, ',')) {
+                if (auto key = "sccs"sv; eqIgnoreCase(value, key, key.size())) {
+                    reifyFlags |= ReifyFlag::reify_scc;
+                    value.remove_prefix(key.size());
+                }
+                else if (key = "steps"sv; eqIgnoreCase(value, key, key.size())) {
+                    reifyFlags |= ReifyFlag::reify_step;
+                    value.remove_prefix(key.size());
+                }
+                else {
+                    break;
+                }
+            }
         }
-        if (eqIgnoreCase(value, "smodels"sv)) {
-            pre = static_cast<int8_t>(AspParser::format_smodels);
-            return true;
-        }
+        return value.empty();
     }
     else if (name == "out-ifs"sv && not value.empty() && value.size() == 1 + (value[0] == '\\')) {
         if (auto x = value.size() == 1 ? value[0] : [](char c) {
@@ -592,14 +602,19 @@ void ClaspAppBase::handlePrepareEvent(ClaspFacade& clasp) {
     if (auto* asp = clasp.asp(); claspConfig_.onlyPre) {
         if (asp) {
             asp->endProgram();
-            auto        outf = static_cast<AspParser::Format>(claspAppOpts_.pre);
-            const char* err;
-            if (outf == AspParser::format_smodels && not asp->supportsSmodels(&err)) {
-                fail(
-                    exit_error, "Option '--pre': unsupported input format!",
-                    std::string(err).append(" directive not supported!\nTry '--pre=aspif' to print in 'aspif' format"));
+            switch (claspAppOpts_.pre) {
+                default                        : Asp::write(*asp, std::cout); break;
+                case ClaspAppOptions::pre_aspif: Asp::writeAspif(*asp, std::cout); break;
+                case ClaspAppOptions::pre_smodels:
+                    if (const char* err; not asp->supportsSmodels(&err)) {
+                        fail(exit_error, "Option '--pre': unsupported input format!",
+                             std::string(err).append(
+                                 " directive not supported!\nTry '--pre=aspif' to print in 'aspif' format"));
+                    }
+                    Asp::writeSmodels(*asp, std::cout);
+                    break;
+                case ClaspAppOptions::pre_reify: Asp::writeReified(*asp, std::cout, claspAppOpts_.reifyFlags); break;
             }
-            AspParser::write(*asp, std::cout, outf);
         }
         else {
             fail(exit_error, "Option '--pre': unsupported input format!");

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -31,6 +31,7 @@
 #include <clasp/solver.h>
 
 #include <potassco/aspif.h>
+#include <potassco/reify.h>
 #include <potassco/smodels.h>
 #include <potassco/theory_data.h>
 
@@ -119,21 +120,22 @@ AspParser::StrategyType* AspParser::doAccept(std::istream& str, const ParserOpti
     in_->setMaxVar(var_max - 1);
     return in_->accept(str) ? in_.get() : nullptr;
 }
-
-void AspParser::write(Asp::LogicProgram& prg, std::ostream& os) {
-    write(prg, os, prg.supportsSmodels() ? format_smodels : format_aspif);
+namespace Asp {
+void write(LogicProgram& prg, std::ostream& os) { prg.supportsSmodels() ? writeSmodels(prg, os) : writeAspif(prg, os); }
+void writeSmodels(LogicProgram& prg, std::ostream& os) {
+    Potassco::SmodelsOutput out(os, true, prg.falseAtom());
+    prg.accept(out, true);
 }
-void AspParser::write(Asp::LogicProgram& prg, std::ostream& os, Format f) {
-    using namespace Potassco;
-    if (f == format_aspif) {
-        AspifOutput out(os);
-        prg.accept(out, true);
-    }
-    else {
-        SmodelsOutput out(os, true, prg.falseAtom());
-        prg.accept(out, true);
-    }
+void writeAspif(LogicProgram& prg, std::ostream& os) {
+    Potassco::AspifOutput out(os);
+    prg.accept(out, true);
 }
+void writeReified(LogicProgram& prg, std::ostream& os, ReifyFlag flags) {
+    using enum ReifyFlag;
+    Potassco::Reifier out(os, {Potassco::test(flags, reify_scc), Potassco::test(flags, reify_step)});
+    prg.accept(out, true);
+}
+} // namespace Asp
 /////////////////////////////////////////////////////////////////////////////////////////
 // clasp specific extensions for Dimacs/OPB
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -122,12 +122,12 @@ AspParser::StrategyType* AspParser::doAccept(std::istream& str, const ParserOpti
 }
 namespace Asp {
 void write(LogicProgram& prg, std::ostream& os) { prg.supportsSmodels() ? writeSmodels(prg, os) : writeAspif(prg, os); }
-void writeSmodels(LogicProgram& prg, std::ostream& os) {
-    Potassco::SmodelsOutput out(os, true, prg.falseAtom());
-    prg.accept(out, true);
-}
 void writeAspif(LogicProgram& prg, std::ostream& os) {
     Potassco::AspifOutput out(os);
+    prg.accept(out, true);
+}
+void writeSmodels(LogicProgram& prg, std::ostream& os) {
+    Potassco::SmodelsOutput out(os, true, prg.falseAtom());
     prg.accept(out, true);
 }
 void writeReified(LogicProgram& prg, std::ostream& os, ReifyFlag flags) {

--- a/tests/dlp_builder_test.cpp
+++ b/tests/dlp_builder_test.cpp
@@ -351,7 +351,7 @@ TEST_CASE("Disjunctive logic programs", "[asp][dlp]") {
         exp.clear();
         exp.seekg(0);
         std::stringstream str;
-        AspParser::write(lp, str, AspParser::format_smodels);
+        writeSmodels(lp, str);
         REQUIRE_FALSE(findProgram(exp, str));
         exp.clear();
         exp.str("");
@@ -371,7 +371,7 @@ TEST_CASE("Disjunctive logic programs", "[asp][dlp]") {
         REQUIRE(lp.stats.bodies[0][to_underlying(BodyType::count)] == 2);
         REQUIRE(lp.endProgram());
         std::stringstream str;
-        AspParser::write(lp, str, AspParser::format_smodels);
+        writeSmodels(lp, str);
         std::stringstream exp;
         exp << "1 1 1 0 3\n"    // a :- c.
             << "1 1 1 0 2\n"    // a :- b.
@@ -388,7 +388,7 @@ TEST_CASE("Disjunctive logic programs", "[asp][dlp]") {
         REQUIRE(lp.stats.bodies[0][to_underlying(BodyType::count)] == 1);
         REQUIRE(lp.endProgram());
         std::stringstream str;
-        AspParser::write(lp, str, AspParser::format_smodels);
+        writeSmodels(lp, str);
         std::stringstream exp;
         exp << "8 2 1 2 1 0 5\n" // a | b :- aux.
             << "1 5 1 0 1\n"     // aux :- a.

--- a/tests/lpcompare.h
+++ b/tests/lpcompare.h
@@ -79,12 +79,12 @@ inline bool findProgram(std::stringstream& what, std::stringstream& actual) {
 }
 inline bool compareSmodels(std::stringstream& exp, Asp::LogicProgram& prg) {
     std::stringstream str;
-    AspParser::write(prg, str, AspParser::format_smodels);
+    writeSmodels(prg, str);
     return compareProgram(exp, str);
 }
 inline bool findSmodels(std::stringstream& exp, Asp::LogicProgram& prg) {
     std::stringstream str;
-    AspParser::write(prg, str, AspParser::format_smodels);
+    writeSmodels(prg, str);
     return findProgram(exp, str);
 }
 

--- a/tests/parser_test.cpp
+++ b/tests/parser_test.cpp
@@ -279,7 +279,7 @@ TEST_CASE("Smodels parser", "[parser][asp]") {
 
 static bool sameProgram(Asp::LogicProgram& a, std::stringstream& prg) {
     std::stringstream out;
-    AspParser::write(a, out, AspParser::format_aspif);
+    Asp::writeAspif(a, out);
     prg.clear();
     prg.seekg(0);
     return compareProgram(prg, out);
@@ -580,7 +580,7 @@ TEST_CASE("Aspif parser", "[parser][asp]") {
         REQUIRE(ctx.output.size() == 1);
         REQUIRE(ctx.output.pred_range().front().user == 0);
         std::stringstream out;
-        AspParser::write(api, out, AspParser::format_aspif);
+        writeAspif(api, out);
         REQUIRE(out.str() == "asp 2 0 0\n"
                              "1 0 1 1 0 0\n"
                              "4 0 1 1 a\n"
@@ -730,7 +730,7 @@ TEST_CASE("Aspif parser", "[parser][asp]") {
         REQUIRE(parse(api, in));
         REQUIRE((api.endProgram() && api.theoryData().numAtoms() == 1));
         std::stringstream out;
-        AspParser::write(api, out);
+        write(api, out);
         REQUIRE(findProgram(step1, out));
         ProgramParser& p = api.parser();
         REQUIRE(p.more());
@@ -738,7 +738,7 @@ TEST_CASE("Aspif parser", "[parser][asp]") {
         REQUIRE(api.theoryData().empty());
         REQUIRE(p.parse());
         REQUIRE((api.endProgram() && api.theoryData().numAtoms() == 1));
-        AspParser::write(api, out);
+        write(api, out);
     }
     SECTION("testTheoryElementWithCondition") {
         std::vector<uint32_t> ids;
@@ -766,7 +766,7 @@ TEST_CASE("Aspif parser", "[parser][asp]") {
         REQUIRE(cond.size() == 2);
         std::stringstream out;
         REQUIRE(api.endProgram());
-        AspParser::write(api, out);
+        write(api, out);
         REQUIRE(findProgram(out, in));
     }
     SECTION("testBasicAdapter") { REQUIRE_THROWS_AS(BasicProgramAdapter(api), std::logic_error); }

--- a/tests/program_builder_test.cpp
+++ b/tests/program_builder_test.cpp
@@ -531,7 +531,7 @@ TEST_CASE("Logic program", "[asp]") {
         REQUIRE(lp.endProgram());
         REQUIRE(ctx.hasMinimize());
         std::stringstream str;
-        AspParser::write(lp, str, AspParser::format_aspif);
+        writeAspif(lp, str);
         REQUIRE(str.str().find("2 0 1 1") != std::string::npos);
     }
 
@@ -1113,7 +1113,7 @@ TEST_CASE("Logic program", "[asp]") {
         lp.endProgram();
         REQUIRE(lp.getLiteral(a) != lit_false);
         std::stringstream str;
-        AspParser::write(lp, str, AspParser::format_aspif);
+        writeAspif(lp, str);
         for (std::string x; std::getline(str, x);) {
             REQUIRE_FALSE(x.starts_with("1 1"));
             REQUIRE_FALSE(x.starts_with("5 1"));
@@ -1198,7 +1198,7 @@ TEST_CASE("Logic program", "[asp]") {
         REQUIRE(lp.getLiteral(a) == lit_false);
         REQUIRE(t.numAtoms() == 1);
         std::stringstream str;
-        AspParser::write(lp, str, AspParser::format_aspif);
+        writeAspif(lp, str);
         REQUIRE(str.str().find("1 0 0 0 1 1") != std::string::npos);
     }
     SECTION("testGeneralOutputNotSupportedInSmodels") {
@@ -1242,7 +1242,7 @@ TEST_CASE("Logic program", "[asp]") {
         REQUIRE_FALSE(lp.supportsSmodels());
         std::stringstream str;
         SECTION("beforeEnd") {
-            AspParser::write(lp, str, AspParser::format_aspif);
+            writeAspif(lp, str);
             REQUIRE(str.str() == "asp 2 0 0\n"
                                  "5 2 2\n"          // #external b.
                                  "1 0 1 7 0 0\n"    // g.
@@ -1263,7 +1263,7 @@ TEST_CASE("Logic program", "[asp]") {
         }
         SECTION("afterEnd") {
             lp.endProgram();
-            AspParser::write(lp, str, AspParser::format_aspif);
+            writeAspif(lp, str);
             REQUIRE(str.str() == "asp 2 0 0\n"
                                  "1 0 1 6 0 0\n"  // f.
                                  "1 0 1 7 0 0\n"  // g.
@@ -1283,7 +1283,7 @@ TEST_CASE("Logic program", "[asp]") {
             SECTION("beforeEnd") {
                 lp.dispose();
                 REQUIRE(lp.ok());
-                AspParser::write(lp, str, AspParser::format_aspif);
+                writeAspif(lp, str);
                 REQUIRE(str.str() == "asp 2 0 0\n"
                                      "1 0 1 7 0 0\n" // g.
                                      "1 0 1 8 0 0\n" // h.
@@ -1294,7 +1294,7 @@ TEST_CASE("Logic program", "[asp]") {
                 lp.endProgram();
                 lp.dispose();
                 REQUIRE(lp.ok());
-                AspParser::write(lp, str, AspParser::format_aspif);
+                writeAspif(lp, str);
                 REQUIRE(str.str() == "asp 2 0 0\n"
                                      "1 0 1 6 0 0\n" // f.
                                      "1 0 1 7 0 0\n" // g.
@@ -1305,7 +1305,7 @@ TEST_CASE("Logic program", "[asp]") {
             SECTION("full") {
                 lp.start(*lp.ctx(), lp.options());
                 REQUIRE(lp.ok());
-                AspParser::write(lp, str, AspParser::format_aspif);
+                writeAspif(lp, str);
                 REQUIRE(str.str() == "asp 2 0 0\n0\n");
                 lp.endProgram();
             }
@@ -1339,7 +1339,7 @@ TEST_CASE("Logic program", "[asp]") {
         });
         REQUIRE(str.str() == "{1;3}{2;-4}{-2;3}");
         str.str("");
-        AspParser::write(lp, str, AspParser::format_aspif);
+        writeAspif(lp, str);
         REQUIRE(str.str() == "asp 2 0 0\n"
                              "1 0 1 4 0 0\n"
                              "1 1 3 1 2 3 0 0\n"
@@ -1371,7 +1371,7 @@ TEST_CASE("Logic program", "[asp]") {
 
         str.str("");
         lp.endProgram();
-        AspParser::write(lp, str, AspParser::format_aspif);
+        writeAspif(lp, str);
         REQUIRE(str.str() == "asp 2 0 0\n"
                              "1 0 1 4 0 0\n"
                              "1 1 3 1 2 3 0 0\n"
@@ -2334,7 +2334,7 @@ TEST_CASE("Incremental logic program", "[asp]") {
         lpAdd(lp, "#external a.");
         lp.endProgram();
         std::stringstream str;
-        AspParser::write(lp, str, AspParser::format_aspif);
+        writeAspif(lp, str);
         bool foundA = false, foundB = false;
         for (std::string x; std::getline(str, x);) {
             if (x.starts_with("5 1 2")) {
@@ -2350,7 +2350,7 @@ TEST_CASE("Incremental logic program", "[asp]") {
         lp.endProgram();
         foundA = foundB = false;
         str.clear();
-        AspParser::write(lp, str, AspParser::format_aspif);
+        writeAspif(lp, str);
         for (std::string x; std::getline(str, x);) {
             if (x.starts_with("5 1 2")) {
                 foundA = true;
@@ -2372,7 +2372,7 @@ TEST_CASE("Incremental logic program", "[asp]") {
                   "b.");
         lp.endProgram();
         std::stringstream str;
-        AspParser::write(lp, str, AspParser::format_aspif);
+        writeAspif(lp, str);
         int foundA = 0, foundB = 0, foundC = 0, foundD = 0;
         for (std::string x; std::getline(str, x);) {
             if (x.starts_with("5 1 2")) {
@@ -2404,7 +2404,7 @@ TEST_CASE("Incremental logic program", "[asp]") {
         lp.endProgram();
         REQUIRE_FALSE(lp.isExternal(a));
         std::stringstream str;
-        AspParser::write(lp, str, AspParser::format_aspif);
+        writeAspif(lp, str);
         bool found = false;
         for (std::string x; std::getline(str, x);) {
             if (x.starts_with("5 1 3")) {
@@ -2625,7 +2625,7 @@ TEST_CASE("Incremental logic program", "[asp]") {
         REQUIRE(lp.getLiteral(a) != lit_false);
         REQUIRE(lp.getLiteral(b) != lit_false);
         std::stringstream str;
-        AspParser::write(lp, str, AspParser::format_aspif);
+        writeAspif(lp, str);
         for (std::string x; std::getline(str, x);) { REQUIRE(x.find("5 1") != 0); }
         lp.update();
         lpAdd(lp, "{c}."
@@ -2717,7 +2717,7 @@ TEST_CASE("Incremental logic program", "[asp]") {
         lp.addShowTerm(multi, Potassco::LitVec{-5, -6});
 
         std::stringstream str;
-        AspParser::write(lp, str, AspParser::format_aspif);
+        writeAspif(lp, str);
         REQUIRE(str.str() == "1 1 2 5 6 0 0\n"
                              "4 2 1 2 6 -7\n"
                              "4 2 4 2 -5 -6\n"
@@ -2725,7 +2725,7 @@ TEST_CASE("Incremental logic program", "[asp]") {
 
         lp.endProgram();
         str.str("");
-        AspParser::write(lp, str, AspParser::format_aspif);
+        writeAspif(lp, str);
         REQUIRE(str.str() == "1 1 2 5 6 0 0\n"
                              "4 2 1 1 6\n"
                              "4 2 4 2 -5 -6\n"
@@ -2746,7 +2746,7 @@ TEST_CASE("Incremental logic program", "[asp]") {
         lp.addShowTerm(multi, Potassco::LitVec{});
         lp.endProgram();
         str.str("");
-        AspParser::write(lp, str, AspParser::format_aspif);
+        writeAspif(lp, str);
         REQUIRE(str.str() == "4 2 4 0\n"
                              "0\n");
     }


### PR DESCRIPTION
This PR adds support for reified output in the `--pre` option, along with the `--reify-sccs` and `--reify-steps` flags.

The `libpotassco` submodule is updated to the commit introducing the `Reifier`.
