### PR TITLE
Rework ClaspStatistics to make it more portable.

### DIFF
--- a/clasp/clasp_facade.h
+++ b/clasp/clasp_facade.h
@@ -215,6 +215,10 @@ public:
     };
     using Result             = SolveResult;
     using AbstractStatistics = Potassco::AbstractStatistics;
+    //! Stats key for user-defined (clingo) step statistics.
+    static constexpr auto user_step_stats = std::string_view{"user_step"};
+    //! Stats key for user-defined (clingo) accu statistics.
+    static constexpr auto user_accu_stats = std::string_view{"user_accu"};
     //! Type summarizing one or more solving steps.
     struct Summary {
         using FacadePtr = const ClaspFacade*;
@@ -244,7 +248,7 @@ public:
         [[nodiscard]] bool         hasLower() const;
         [[nodiscard]] SumView      lower() const;
         //@}
-        //! Visits this summary object.
+        //! Visits this summary object and all associated statistics (including any user-added clingo stats).
         void      accept(StatsVisitor& out) const;
         FacadePtr facade;     //!< Facade object of this run.
         double    totalTime;  //!< Total wall clock time.

--- a/clasp/dependency_graph.h
+++ b/clasp/dependency_graph.h
@@ -97,9 +97,10 @@ public:
         NonHcfStats(NonHcfStats&&) = delete;
 
         void accept(StatsVisitor& out, bool final) const;
+        void accept(ClaspStatistics& stats, ClaspStatistics::Key_t problem, ClaspStatistics::Key_t solving,
+                    const ClaspStatistics::Key_t* accu) const;
         void startStep(uint32_t statsLevel);
         void endStep();
-        void addTo(StatsMap& problem, StatsMap& solving, StatsMap* accu) const;
 
     private:
         friend class PrgDepGraph;

--- a/clasp/logic_program.h
+++ b/clasp/logic_program.h
@@ -55,7 +55,7 @@ struct RuleStats {
         key_num
     };
     //! Returns a string representation of the given key.
-    static const char* toStr(unsigned k);
+    static auto toStr(unsigned k) -> std::string_view;
     //! Returns the number of keys distinguished by this type.
     static uint32_t numKeys() { return key_num; }
     //! Updates the number of rules with the given type.
@@ -75,7 +75,7 @@ struct BodyStats {
     //! Body types distinguished by this object.
     using Key = BodyType;
     //! Returns a string representation of the given key.
-    static const char* toStr(unsigned k);
+    static auto toStr(unsigned k) -> std::string_view;
     //! Returns the number of keys distinguished by this type.
     static uint32_t numKeys() { return Potassco::enum_max<BodyType>() + 1; }
     //! Updates the number of bodies with the given type.
@@ -102,9 +102,9 @@ public:
     //! Computes *this += o.
     void accu(const LpStats& o);
     // StatisticObject
-    static uint32_t               size();
-    static std::string_view       key(uint32_t i);
-    [[nodiscard]] StatisticObject at(std::string_view k) const;
+    static auto        size() -> uint32_t;
+    static auto        key(uint32_t i) -> std::string_view;
+    [[nodiscard]] auto at(std::string_view k) const -> StatisticObject;
 
     RuleStats rules[2]{};        /**< RuleStats (initial, final). */
     BodyStats bodies[2]{};       /**< BodyStats (initial, final). */

--- a/clasp/shared_context.h
+++ b/clasp/shared_context.h
@@ -289,9 +289,9 @@ struct ProblemStats {
         acycEdges           += o.acycEdges;
     }
     // StatisticObject
-    static uint32_t               size();
-    static std::string_view       key(uint32_t i);
-    [[nodiscard]] StatisticObject at(std::string_view k) const;
+    static auto        size() -> uint32_t;
+    static auto        key(uint32_t i) -> std::string_view;
+    [[nodiscard]] auto at(std::string_view k) const -> StatisticObject;
 };
 
 //! Stores static information about a variable.

--- a/clasp/solver_types.h
+++ b/clasp/solver_types.h
@@ -44,17 +44,16 @@ class SharedLiterals;
 // Statistics
 ///////////////////////////////////////////////////////////////////////////////
 class StatisticObject;
-class StatsMap;
 #if !defined(DOXY)
 #define DOXY(X)
 #endif
 #define CLASP_STAT_DEFINE(m, k, a, accu) m
 #define NO_ARG
 #define CLASP_DECLARE_ISTATS(T)                                                                                        \
-    void                    accu(const T& o);                                                                          \
-    static uint32_t         size();                                                                                    \
-    static std::string_view key(uint32_t i);                                                                           \
-    StatisticObject         at(std::string_view key) const
+    void        accu(const T& o);                                                                                      \
+    static auto size() -> uint32_t;                                                                                    \
+    static auto key(uint32_t i) -> std::string_view;                                                                   \
+    auto        at(std::string_view key) const -> StatisticObject
 
 //! A struct for holding core statistics used by a solver.
 /*!
@@ -219,7 +218,6 @@ struct SolverStats : CoreStats {
     [[nodiscard]] auto size() const -> uint32_t;
     [[nodiscard]] auto key(uint32_t i) const -> std::string_view;
     [[nodiscard]] auto at(std::string_view key) const -> StatisticObject;
-    void               addTo(std::string_view key, StatsMap& solving, StatsMap* accu) const;
     inline void        addLearnt(uint32_t size, ConstraintType t);
     inline void        addConflict(uint32_t dl, uint32_t uipLevel, uint32_t bLevel, uint32_t lbd);
     inline void        addDeleted(uint32_t num);

--- a/clasp/statistics.h
+++ b/clasp/statistics.h
@@ -26,69 +26,111 @@
 #pragma once
 
 #include <clasp/claspfwd.h>
+
 #include <clasp/pod_vector.h>
+
 #include <potassco/clingo.h>
+
+#include <concepts>
+#include <string_view>
+
 namespace Clasp {
+class StatisticObject;
+//! A statistic value is any object that can be converted to a double.
+template <typename T>
+concept StatisticValue = requires(const T& u) { static_cast<double>(u); };
+//! Specifies the interface that a type must provide to be a valid statistic map.
+/*!
+ * For a type T to be a statistic map, it has to provide:
+ *  - a function `size()`, which returns the number of keys in the map,
+ *  - a function `key(i)`, which given an index `0 <= i < size()` returns the ith key in the map,
+ *  - a function `at(k)`, which given a key `k` returns the StatisticObject associated with the key.
+ *
+ *  \note T might throw an exception if a given index is out of bounds or a key is not present.
+ */
+template <typename T>
+concept StatisticMap = requires(const T& u) {
+    { u.size() } -> std::unsigned_integral;
+    { u.key(std::declval<uint32_t>()) } -> std::convertible_to<std::string_view>;
+    { u.at(std::declval<std::string_view>()) } -> std::convertible_to<StatisticObject>;
+};
+//! Specifies the interface that a type must provide to be a valid statistic array.
+/*!
+ * For a type T to be a statistic array, it has to provide:
+ *  - a function `size()`, which returns the size of the array,
+ *  - a function `at(i)`, which given an index `0 <= i < size()` returns the ith StatisticObject element in the array.
+ *
+ *  \note T might throw an exception if a given index is out of bounds.
+ */
+template <typename T>
+concept StatisticArray = requires(const T& u) {
+    { u.size() } -> std::unsigned_integral;
+    { u.at(std::declval<uint32_t>()) } -> std::convertible_to<StatisticObject>;
+};
 
 //! Discriminated union representing either a single statistic value or a composite.
 class StatisticObject {
 public:
     using Type = Potassco::StatisticsType;
     //! Creates a Type::value object with value 0.0.
-    StatisticObject();
+    StatisticObject() : StatisticObject(nullptr, Value::create<double, &alwaysNull>()) {}
     //! Creates a Type::value object - static_cast<double>(*obj) shall be valid.
-    template <typename T>
-    static StatisticObject value(const T* obj) {
-        return value<T, toDouble>(obj);
+    template <StatisticValue T>
+    static auto value(const T* obj) -> StatisticObject {
+        return {obj, Value::create<T, toDouble<T>>()};
     }
-    //! Creates a mapped Type::value object: f(obj) -> double
-    template <typename T, double (*Op)(const T*)>
-    static StatisticObject value(const T* obj) {
-        return StatisticObject(obj, registerValue<T, Op>());
+    //! Creates a mapped Type::value object: GetOp(obj) -> double
+    template <auto GetOp, typename T>
+    requires std::is_invocable_r_v<double, decltype(GetOp), const T*>
+    static auto value(const T* obj) -> StatisticObject {
+        return {obj, Value::create<T, GetOp>()};
     }
     //! Creates a Type::map object.
-    /*!
-     * The following expression shall be valid:
-     * - obj->size(): shall return the number of keys in obj
-     * - obj->key(i): shall return the i-th key of this object (i >= 0).
-     * - obj->at(std::string_view k): shall return the StatisticObject under the given key.
-     *  If k is invalid, shall either throw an exception or return an empty object.
-     */
-    template <typename T>
-    static StatisticObject map(const T* obj) {
-        return StatisticObject(obj, registerMap<T>());
+    template <StatisticMap T>
+    static auto map(const T* obj) -> StatisticObject {
+        return {obj, Map::create<T>()};
     }
     //! Creates a Type::array object.
-    /*!
-     * The following expression shall be valid:
-     * - obj->size(): shall return the size of the array.
-     * - obj->at(i): shall return the StatisticObject under the given index i >= 0.
-     *  If the index is invalid, shall either throw an exception or return an empty object.
-     */
-    template <typename T>
-    static StatisticObject array(const T* obj) {
-        return StatisticObject(obj, registerArray<T>());
+    template <StatisticArray T>
+    static auto array(const T* obj) -> StatisticObject {
+        return {obj, Array::create<T>()};
     }
-    //! Returns the type of this object.
-    [[nodiscard]] Type type() const;
-    //! Returns the number of children of this object or 0 if this is not a composite object.
-    [[nodiscard]] uint32_t size() const;
+    //! Creates a Type::array object with `GetOp` as at() function.
+    /*!
+     * GetOp(const ContainerT::value_type&) -> StatisticObject
+     */
+    template <auto GetOp, typename ContainerT>
+    requires std::is_invocable_r_v<StatisticObject, decltype(GetOp), const typename ContainerT::value_type&>
+    static auto array(const ContainerT* obj) -> StatisticObject {
+        return {obj, Array::create<ContainerT, &Array::getValueExt<ContainerT, GetOp>>()};
+    }
+    //! Returns the statistic type of this object.
+    [[nodiscard]] constexpr auto type() const -> Type { return vtab_->type; }
+    //! Returns the number of children of this object or 0 if `type() == Type::value`.
+    [[nodiscard]] constexpr auto size() const -> uint32_t {
+        if (auto t = type(); t == Type::value) {
+            return 0u;
+        }
+        else {
+            return (t == Type::array ? arr()->size : map()->size)(object());
+        }
+    }
 
     /*!
      * \name Map
      * \pre type() == Type::map
      */
     //@{
-    //! Returns the i-th key of this map.
+    //! Returns the ith key of this map.
     /*!
      * \pre i < size()
      */
-    [[nodiscard]] std::string_view key(uint32_t i) const;
+    [[nodiscard]] constexpr auto key(uint32_t i) const -> std::string_view { return map()->key(object(), i); }
     //! Returns the object under the given key.
     /*!
      * \pre k in key([0;size()))
      */
-    [[nodiscard]] StatisticObject at(std::string_view k) const;
+    [[nodiscard]] constexpr auto at(std::string_view k) const -> StatisticObject { return map()->at(object(), k); }
     //@}
 
     //! Returns the object at the given index.
@@ -96,175 +138,113 @@ public:
      * \pre type() == Type::array
      * \pre i < size()
      */
-    StatisticObject operator[](uint32_t i) const;
+    [[nodiscard]] constexpr auto operator[](uint32_t i) const -> StatisticObject { return arr()->at(object(), i); }
 
     //! Returns the value of this object.
     /*!
      * \pre type() == Type::value
      */
-    [[nodiscard]] double value() const;
+    [[nodiscard]] constexpr auto value() const -> double { return val()->value(object()); }
 
-    [[nodiscard]] std::size_t hash() const;
-    [[nodiscard]] uint64_t    toRep() const;
-    [[nodiscard]] const void* self() const;
-    [[nodiscard]] std::size_t typeId() const;
-    static StatisticObject    fromRep(uint64_t);
+    constexpr bool operator==(const StatisticObject&) const  = default;
+    constexpr auto operator<=>(const StatisticObject&) const = default;
 
-    bool operator==(const StatisticObject&) const  = default;
-    auto operator<=>(const StatisticObject&) const = default;
+    [[nodiscard]] constexpr auto object() const -> const void* { return obj_; }
+    [[nodiscard]] constexpr auto typeId() const -> const void* { return vtab_; }
+    [[nodiscard]] constexpr bool eqTypeId(const StatisticObject& other) const { return vtab_ == other.vtab_; }
 
 private:
+    static constexpr auto toDouble(const auto* v) -> double { return static_cast<double>(*v); }
+    static constexpr auto alwaysNull(const double*) -> double { return 0.0; }
     template <typename T>
-    static double toDouble(const T* v) {
-        return static_cast<double>(*v);
+    static constexpr auto getSize(const void* o) -> uint32_t {
+        return toU32(static_cast<const T*>(o)->size());
     }
-    struct I {
+    ///////////////////////////////////////////////////////
+    // Vtable types
+    ///////////////////////////////////////////////////////
+    struct VtabBase {
         using ObjPtr = const void*;
-        explicit I(Type t) : type(t) {}
+        using SzFun  = auto (*)(ObjPtr) -> uint32_t;
+        constexpr explicit VtabBase(Type t) : type(t) {}
         template <typename T>
-        const T* as() const {
-            return static_cast<const T*>(this);
+        [[nodiscard]] constexpr const T* as() const {
+            if (T::type == type) {
+                return static_cast<const T*>(this);
+            }
+            Potassco::AbstractStatistics::throwType(T::type, type);
         }
         Type type;
     };
-    struct V : I {
-        explicit V(double (*v)(ObjPtr)) : I(Type::value), value(v) {}
-        double (*value)(ObjPtr);
+    struct Value : VtabBase {
+        static constexpr auto type = Type::value;
+        template <typename T, double (*Op)(const T*)>
+        static auto get(ObjPtr o) -> double {
+            return Op(static_cast<const T*>(o));
+        }
+        template <typename T, double (*Op)(const T*)>
+        static const Value* create() {
+            static constexpr auto vtab_s = Value{&get<T, Op>};
+            return &vtab_s;
+        }
+        using ValFun = auto (*)(ObjPtr) -> double;
+        constexpr explicit Value(ValFun v) : VtabBase(Type::value), value(v) {}
+        ValFun value;
     };
-    struct A : I {
-        A(uint32_t (*sz)(ObjPtr), StatisticObject (*a)(ObjPtr, uint32_t)) : I(Type::array), size(sz), at(a) {}
-        uint32_t (*size)(ObjPtr);
-        StatisticObject (*at)(ObjPtr, uint32_t);
+    struct Array : VtabBase {
+        static constexpr auto type = Type::array;
+        using AtFun                = auto (*)(ObjPtr, uint32_t) -> StatisticObject;
+        template <typename T>
+        static constexpr auto getValue(ObjPtr o, uint32_t i) -> StatisticObject {
+            return static_cast<const T*>(o)->at(i);
+        }
+        template <typename T, auto Op>
+        static constexpr auto getValueExt(ObjPtr o, uint32_t i) -> StatisticObject {
+            return Op(static_cast<const T*>(o)->at(i));
+        }
+        template <typename T, AtFun Op = &getValue<T>>
+        static const Array* create() {
+            static constexpr auto vtab_s = Array{&getSize<T>, Op};
+            return &vtab_s;
+        }
+        constexpr Array(SzFun sz, AtFun a) : VtabBase(Type::array), size(sz), at(a) {}
+        SzFun size;
+        AtFun at;
     };
-    struct M : I {
-        M(uint32_t (*sz)(ObjPtr), StatisticObject (*a)(ObjPtr, std::string_view),
-          std::string_view (*k)(ObjPtr, uint32_t))
-            : I(Type::map)
-            , size(sz)
-            , at(a)
-            , key(k) {}
-        uint32_t (*size)(ObjPtr);
-        StatisticObject (*at)(ObjPtr, std::string_view);
-        std::string_view (*key)(ObjPtr, uint32_t);
+    struct Map : VtabBase {
+        static constexpr auto type = Type::map;
+        template <typename T>
+        static constexpr auto getKey(ObjPtr o, uint32_t i) -> std::string_view {
+            return static_cast<const T*>(o)->key(i);
+        }
+        template <typename T>
+        static constexpr auto getValue(ObjPtr o, std::string_view k) -> StatisticObject {
+            return static_cast<const T*>(o)->at(k);
+        }
+        template <typename T>
+        static const Map* create() {
+            static constexpr auto vtab_s = Map{&getSize<T>, &getKey<T>, &getValue<T>};
+            return &vtab_s;
+        }
+        using KeyFun = auto (*)(ObjPtr, uint32_t) -> std::string_view;
+        using AtFun  = auto (*)(ObjPtr, std::string_view) -> StatisticObject;
+        constexpr Map(SzFun sz, KeyFun k, AtFun a) : VtabBase(Type::map), size(sz), key(k), at(a) {}
+        SzFun  size;
+        KeyFun key;
+        AtFun  at;
     };
-    static uint32_t registerType(const I* vtab) {
-        s_types_.push_back(vtab);
-        return size32(s_types_) - 1;
-    }
-    template <typename T, double (*Fun)(const T*)>
-    static uint32_t registerValue();
-    template <typename T>
-    static uint32_t registerMap();
-    template <typename T>
-    static uint32_t registerArray();
-    StatisticObject(const void* obj, uint32_t type);
-    explicit StatisticObject(uint64_t h);
-
-    using RegVec = PodVector_t<const I*>;
-    [[nodiscard]] const I* tid() const;
-    static V               s_empty_;
-    static RegVec          s_types_;
-    uint64_t               handle_;
+    [[nodiscard]] constexpr auto val() const -> const Value* { return vtab_->as<Value>(); }
+    [[nodiscard]] constexpr auto arr() const -> const Array* { return vtab_->as<Array>(); }
+    [[nodiscard]] constexpr auto map() const -> const Map* { return vtab_->as<Map>(); }
+    ///////////////////////////////////////////////////////
+    constexpr StatisticObject(const void* obj, const VtabBase* vtab) : obj_(obj), vtab_(vtab) {}
+    const void*     obj_{nullptr};
+    const VtabBase* vtab_{nullptr};
 };
 
-template <typename T>
-uint32_t StatisticObject::registerArray() {
-    static const struct Array_t : A {
-        Array_t() : A(&Array_t::size, &Array_t::at) {}
-        static uint32_t        size(ObjPtr obj) { return toU32(static_cast<const T*>(obj)->size()); }
-        static StatisticObject at(ObjPtr obj, uint32_t i) { return static_cast<const T*>(obj)->at(i); }
-    } vtab_s;
-    static const uint32_t id = registerType(&vtab_s);
-    return id;
-}
-template <typename T>
-uint32_t StatisticObject::registerMap() {
-    static const struct Map_t : M {
-        Map_t() : M(&Map_t::size, &Map_t::at, &Map_t::key) {}
-        static const T*         cast(ObjPtr obj) { return static_cast<const T*>(obj); }
-        static uint32_t         size(ObjPtr obj) { return cast(obj)->size(); }
-        static StatisticObject  at(ObjPtr obj, std::string_view k) { return cast(obj)->at(k); }
-        static std::string_view key(ObjPtr obj, uint32_t i) { return cast(obj)->key(i); }
-    } vtab_s;
-    static const uint32_t id = registerType(&vtab_s);
-    return id;
-}
-
-template <typename T, double (*Fun)(const T*)>
-uint32_t StatisticObject::registerValue() {
-    static const struct Value_t : V {
-        Value_t() : V(&Value_t::value) {}
-        static double value(ObjPtr obj) { return Fun(static_cast<const T*>(obj)); }
-    } vtab_s;
-    static const uint32_t id = StatisticObject::registerType(&vtab_s);
-    return id;
-}
-//! A type that maps string keys to statistic objects.
-class StatsMap {
-public:
-    // StatisticObject
-    [[nodiscard]] uint32_t         size() const { return size32(keys_); }
-    [[nodiscard]] std::string_view key(uint32_t i) const { return keys_.at(i).first; }
-    [[nodiscard]] StatisticObject  at(std::string_view k) const;
-    // Own interface
-    [[nodiscard]] auto find(std::string_view k) const -> const StatisticObject*;
-    bool               add(std::string_view k, const StatisticObject&);
-    void               push(std::string_view k, const StatisticObject&);
-    [[nodiscard]] auto toStats() const -> StatisticObject { return StatisticObject::map(this); }
-
-private:
-    using MapType = PodVector_t<std::pair<std::string_view, StatisticObject>>;
-    MapType keys_;
-};
-//! An array of statistic objects.
-template <typename T, Potassco::StatisticsType ElemType = Potassco::StatisticsType::map>
-class StatsVec : private PodVector_t<T*> {
-public:
-    StatsVec() = default;
-    ~StatsVec() {
-        if (own_) {
-            for (auto* s : *this) { delete s; }
-        }
-    }
-    StatsVec(const StatsVec&)            = delete;
-    StatsVec& operator=(const StatsVec&) = delete;
-
-    using base_type      = PodVector_t<T*>;                    // NOLINT
-    using const_iterator = typename base_type::const_iterator; // NOLINT
-    using iterator       = typename base_type::iterator;       // NOLINT
-    using base_type::size;
-    using base_type::operator[];
-    using base_type::begin;
-    using base_type::empty;
-    using base_type::end;
-    void growTo(uint32_t newSize) {
-        if (newSize > size()) {
-            this->resize(newSize);
-        }
-    }
-    void reset() {
-        for (T* s : *this) { s->reset(); }
-    }
-    [[nodiscard]] StatisticObject at(uint32_t i) const {
-        const T* ptr = this->base_type::at(i);
-        if constexpr (ElemType == Potassco::StatisticsType::map) {
-            return StatisticObject::map(ptr);
-        }
-        else if constexpr (ElemType == Potassco::StatisticsType::array) {
-            return StatisticObject::array(ptr);
-        }
-        else {
-            static_assert(ElemType == Potassco::StatisticsType::value, "invalid element type");
-            return StatisticObject::value(ptr);
-        }
-    }
-    [[nodiscard]] StatisticObject toStats() const { return StatisticObject::array(this); }
-    void                          acquire() { own_ = true; }
-    void                          release() { own_ = false; }
-
-private:
-    bool own_{true};
-};
+struct SolverStats;
+struct ProblemStats;
+class StatsVisitor;
 
 //! A class for traversing, querying, and adding statistics.
 /*!
@@ -273,42 +253,53 @@ private:
 class ClaspStatistics : public Potassco::AbstractStatistics {
 public:
     ClaspStatistics();
-    explicit ClaspStatistics(StatisticObject root);
     ~ClaspStatistics() override;
     ClaspStatistics(ClaspStatistics&&) = delete;
 
-    StatsMap* makeRoot();
+    //! Exports the given statistic object under the given name in the map with the key `mapK`.
+    /*!
+     * \param mapK      The map object to which `object` should be added.
+     * \param name      The name under which `object` should be exported.
+     * \param object    The statistic object to export.
+     * \param skipCheck Whether to skip the check for a duplicate/existing name.
+     * \return The key of the added statistic object.
+     *
+     * \note If `name` already exists in `mapK`, the behavior depends on `skipCheck`:
+     *   - if `skipCheck` is false, a logic error is raised unless `object` matches with the existing object,
+     *   - if `skipCheck` is true, `object` is added with a new key, but it is not reachable from `mapK`.
+     */
+    auto addObject(Key_t mapK, std::string_view name, StatisticObject object, bool skipCheck = false) -> Key_t;
+    //! Applies the given visitor on the statistic object with the given name.
+    /*!
+     * If a statistic object `o` with the given name exists, calls `visitor.visitExternalStats(o)` and returns true.
+     * Otherwise, the function returns false without calling any function on `visitor`.
+     */
+    bool visitExternal(std::string_view name, StatsVisitor& visitor) const;
+    //! Freezes or thaws access to external statistic objects.
+    /*!
+     * After a call to `freeze(true)`, any attempt to access a non-writable statistic object will result in
+     * a logic error until `freeze(false)` is called.
+     */
+    void freeze(bool);
 
     // Base interface
-    [[nodiscard]] Key_t            root() const override;
-    [[nodiscard]] Type             type(Key_t key) const override;
-    [[nodiscard]] size_t           size(Key_t key) const override;
-    [[nodiscard]] bool             writable(Key_t key) const override;
-    [[nodiscard]] Key_t            at(Key_t arrK, size_t index) const override;
-    Key_t                          push(Key_t arr, Type type) override;
-    [[nodiscard]] std::string_view key(Key_t mapK, size_t i) const override;
-    [[nodiscard]] Key_t            get(Key_t mapK, std::string_view) const override;
-    bool                           find(Key_t mapK, std::string_view element, Key_t* outKey) const override;
-    Key_t                          add(Key_t mapK, std::string_view name, Type type) override;
-    [[nodiscard]] double           value(Key_t key) const override;
-    void                           set(Key_t key, double value) override;
-
-    Key_t changeRoot(Key_t newRoot);
-    bool  removeStat(const StatisticObject&, bool recurse);
-    bool  removeStat(Key_t k, bool recurse);
-
-    // Remove unreachable stats
-    void                          update();
-    [[nodiscard]] StatisticObject getObject(Key_t k) const;
+    [[nodiscard]] auto root() const -> Key_t override;
+    [[nodiscard]] Type type(Key_t key) const override;
+    [[nodiscard]] auto size(Key_t key) const -> size_t override;
+    [[nodiscard]] bool writable(Key_t key) const override;
+    [[nodiscard]] auto at(Key_t arrK, size_t index) const -> Key_t override;
+    [[nodiscard]] auto push(Key_t arr, Type type) -> Key_t override;
+    [[nodiscard]] auto key(Key_t mapK, size_t i) const -> std::string_view override;
+    [[nodiscard]] auto get(Key_t mapK, std::string_view) const -> Key_t override;
+    [[nodiscard]] bool find(Key_t mapK, std::string_view element, Key_t* outKey) const override;
+    [[nodiscard]] auto add(Key_t mapK, std::string_view name, Type type) -> Key_t override;
+    [[nodiscard]] auto value(Key_t key) const -> double override;
+    void               set(Key_t key, double value) override;
 
 private:
-    StatisticObject findObject(Key_t root, std::string_view path, Key_t* track = nullptr) const;
     struct Impl;
     std::unique_ptr<Impl> impl_;
 };
-
-struct SolverStats;
-struct ProblemStats;
 
 //! Interface for visiting statistics.
 /*!
@@ -332,5 +323,4 @@ public:
     virtual void visitSolverStats(const SolverStats& stats)        = 0;
     virtual void visitExternalStats(const StatisticObject& stats)  = 0;
 };
-
 } // namespace Clasp

--- a/clasp/util/misc_types.h
+++ b/clasp/util/misc_types.h
@@ -242,11 +242,11 @@ class TaggedPtr {
 public:
     static_assert(N > 0 && N < (sizeof(void*) * CHAR_BIT), "invalid number of tag bits");
     static constexpr auto c_mask = Potassco::bit_max<uintptr_t>(N);
+    static_assert(alignof(T) > c_mask, "too many tag bits");
 
     constexpr TaggedPtr() noexcept = default;
-    constexpr explicit TaggedPtr(T* ptr) noexcept : ptr_(reinterpret_cast<uintptr_t>(ptr)) {
-        static_assert(alignof(T) > c_mask, "too many tag bits");
-    }
+    constexpr explicit TaggedPtr(T* ptr) noexcept : ptr_(reinterpret_cast<uintptr_t>(ptr)) {}
+    constexpr explicit TaggedPtr(std::true_type, T* ptr) noexcept : ptr_(reinterpret_cast<uintptr_t>(ptr) | c_mask) {}
 
     template <auto I>
     requires(static_cast<std::size_t>(I) < N)

--- a/src/clasp_facade.cpp
+++ b/src/clasp_facade.cpp
@@ -34,6 +34,7 @@
 #include <potassco/format.h>
 
 #include <climits>
+#include <cmath>
 #if CLASP_HAS_THREADS
 #include <clasp/mt/thread.h>
 #endif
@@ -424,38 +425,6 @@ ClaspFacade::SolveStrategy* ClaspFacade::SolveStrategy::create(SolveMode m, Clas
 // ClaspFacade::SolveData
 /////////////////////////////////////////////////////////////////////////////////////////
 struct ClaspFacade::SolveData {
-    struct BoundArray {
-        enum Type { lower, costs };
-        BoundArray(const SolveData* d, Type t) : data(d), type(t) {}
-        ~BoundArray() {
-            while (not refs.empty()) {
-                delete refs.back();
-                refs.pop_back();
-            }
-        }
-        struct LevelRef {
-            LevelRef(const BoundArray* a, uint32_t l) : arr(a), at(l) {}
-            static double     value(const LevelRef* ref) { return ref->arr->bound(ref->at); }
-            const BoundArray* arr;
-            uint32_t          at;
-        };
-        using ElemVec = PodVector_t<LevelRef*>;
-        uint32_t        size() const { return data->numBounds(); }
-        StatisticObject at(uint32_t i) const {
-            POTASSCO_CHECK_PRE(i < size(), "Invalid key");
-            while (i >= refs.size()) { refs.push_back(new LevelRef(this, size32(refs))); }
-            return StatisticObject::value<LevelRef, &LevelRef::value>(refs[i]);
-        }
-        double bound(uint32_t idx) const {
-            POTASSCO_CHECK_PRE(idx < size(), "Expired key");
-            const Wsum_t bound = data->bound(type, idx);
-            return bound != SharedMinimizeData::maxBound() ? static_cast<double>(bound)
-                                                           : std::numeric_limits<double>::infinity();
-        }
-        const SolveData* data;
-        mutable ElemVec  refs;
-        Type             type;
-    };
     using AlgoPtr = std::unique_ptr<SolveAlgorithm>;
     using EnumPtr = std::unique_ptr<Enumerator>;
     using MinPtr  = const SharedMinimizeData*;
@@ -474,31 +443,19 @@ struct ClaspFacade::SolveData {
         }
         return false;
     }
-    bool         onModel(const Solver& s, const Model& m) const { return not active || active->setModel(s, m); }
-    bool         onUnsat(const Solver& s, const Model& m) const { return not active || active->setUnsat(s, m); }
-    bool         solving() const { return active && active->running(); }
-    const Model* lastModel() const { return en.get() ? &en->lastModel() : nullptr; }
-    LitView      unsatCore() const { return active ? active->unsatCore() : LitView{}; }
-    MinPtr       minimizer() const { return en.get() ? en->minimizer() : nullptr; }
-    Enumerator*  enumerator() const { return en.get(); }
-    int          modelType() const { return en.get() ? en->modelType() : 0; }
-    int          signal() const { return solving() ? active->signal() : static_cast<int>(qSig); }
-    uint32_t     numBounds() const { return minimizer() ? minimizer()->numRules() : 0; }
-
-    Wsum_t bound(BoundArray::Type type, uint32_t idx) const {
-        if (const Model* m = lastModel(); m && m->hasCosts() && (m->opt || type == BoundArray::costs)) {
-            POTASSCO_CHECK(idx < m->costs.size(), ERANGE);
-            return m->costs[idx];
-        }
-        const Wsum_t b = type == BoundArray::costs ? minimizer()->sum(idx) : minimizer()->lower(idx);
-        return b + (b != SharedMinimizeData::maxBound() ? minimizer()->adjust(idx) : 0);
-    }
+    [[nodiscard]] bool onModel(const Solver& s, const Model& m) const { return not active || active->setModel(s, m); }
+    [[nodiscard]] bool onUnsat(const Solver& s, const Model& m) const { return not active || active->setUnsat(s, m); }
+    [[nodiscard]] bool solving() const { return active && active->running(); }
+    [[nodiscard]] auto lastModel() const -> const Model* { return en.get() ? &en->lastModel() : nullptr; }
+    [[nodiscard]] auto unsatCore() const -> LitView { return active ? active->unsatCore() : LitView{}; }
+    [[nodiscard]] auto minimizer() const -> MinPtr { return en.get() ? en->minimizer() : nullptr; }
+    [[nodiscard]] auto enumerator() const -> Enumerator* { return en.get(); }
+    [[nodiscard]] auto modelType() const -> int { return en.get() ? en->modelType() : 0; }
+    [[nodiscard]] auto signal() const -> int { return solving() ? active->signal() : static_cast<int>(qSig); }
 
     EnumPtr        en;
     AlgoPtr        algo;
     SolveStrategy* active = nullptr;
-    BoundArray     costs{this, BoundArray::costs};
-    BoundArray     lower{this, BoundArray::lower};
     SigAtomic      qSig;
     bool           keepPrg       = false;
     bool           prepared      = false;
@@ -562,115 +519,205 @@ bool ClaspFacade::SolveHandle::next() const { return strat_->next(); }
 /////////////////////////////////////////////////////////////////////////////////////////
 // ClaspFacade::Statistics
 /////////////////////////////////////////////////////////////////////////////////////////
-namespace {
-struct SummaryStats {
-    struct Stat {
-        std::string_view key;
-        StatisticObject (*get)(const ClaspFacade::Summary*);
-    };
-    template <double ClaspFacade::Summary::*Time>
-    static StatisticObject getT(const ClaspFacade::Summary* x) {
-        return StatisticObject::value(&static_cast<const double&>((x->*Time)));
-    }
-    template <uint64_t ClaspFacade::Summary::*Model>
-    static StatisticObject getM(const ClaspFacade::Summary* x) {
-        return StatisticObject::value(&static_cast<const uint64_t&>((x->*Model)));
-    }
-    using StatRange = SpanView<Stat>;
-
-    static constexpr Stat sum_keys[] = {
-        {"total", getT<&ClaspFacade::Summary::totalTime>},    {"cpu", getT<&ClaspFacade::Summary::cpuTime>},
-        {"solve", getT<&ClaspFacade::Summary::solveTime>},    {"unsat", getT<&ClaspFacade::Summary::unsatTime>},
-        {"sat", getT<&ClaspFacade::Summary::satTime>},        {"enumerated", getM<&ClaspFacade::Summary::numEnum>},
-        {"optimal", getM<&ClaspFacade::Summary::numOptimal>},
-    };
-
-    SummaryStats() = default;
-    void bind(const ClaspFacade::Summary& x, StatRange r) {
-        stats = &x;
-        range = r;
-    }
-    [[nodiscard]] uint32_t         size() const { return size32(range); }
-    [[nodiscard]] std::string_view key(uint32_t i) const {
-        POTASSCO_CHECK(i < size(), ERANGE);
-        return range[i].key;
-    }
-    [[nodiscard]] StatisticObject at(std::string_view key) const {
-        auto it = std::ranges::find_if(range, [&](const Stat& s) { return s.key == key; });
-        POTASSCO_CHECK(it != range.end(), ERANGE);
-        return it->get((stats));
-    }
-    [[nodiscard]] StatisticObject toStats() const { return StatisticObject::map(this); }
-    const ClaspFacade::Summary*   stats{nullptr};
-    StatRange                     range;
-};
-
-} // namespace
-constexpr auto c_get_concurrency = [](const SharedContext* ctx) -> double { return ctx->concurrency(); };
-constexpr auto c_get_winner      = [](const SharedContext* ctx) -> double { return ctx->winner(); };
-constexpr auto c_get_result      = [](const SolveResult* r) -> double {
-    return static_cast<double>(r->operator SolveResult::Res());
-};
-constexpr auto c_get_signal    = [](const SolveResult* r) -> double { return static_cast<double>(r->signal); };
-constexpr auto c_get_exhausted = [](const SolveResult* r) -> double { return static_cast<double>(r->exhausted()); };
+using namespace std::literals;
 
 struct ClaspFacade::Statistics {
     Statistics(ClaspFacade& f) : self_(&f) {}
-    ~Statistics() { delete solvers_.multi; }
+    ~Statistics() {
+        auto deleter = DeleteObject{};
+        std::ranges::for_each(solver_, [&](const TaggedPtr<SolverStats>& p) {
+            if (p && p.any()) {
+                deleter(p->multi);
+                deleter(p.get());
+            }
+        });
+        deleter(solvers_.multi);
+    }
     void               start(uint32_t level);
+    void               freeze();
     void               initLevel(uint32_t level);
     void               enableAsp() { lp_ = std::make_unique<Asp::LpStats>(); }
     void               end();
-    void               addTo(StatsMap& solving, StatsMap* accu) const;
     void               accept(StatsVisitor& out, bool final) const;
     [[nodiscard]] bool incremental() const { return self_->incremental(); }
+    [[nodiscard]] auto solveData() const -> const SolveData* { return self_->solve_.get(); }
 
     // For clingo stats interface
     class ClingoView : public ClaspStatistics {
     public:
         explicit ClingoView(const ClaspFacade& f);
-        void                update(const Statistics& s);
-        [[nodiscard]] Key_t user(bool final) const;
+        void visitUser(bool final, StatsVisitor& out) const;
+        void update(const Statistics& stats);
 
     private:
-        struct StepStats {
-            SummaryStats times;
-            SummaryStats models;
-            void         bind(const Summary& x) {
-                auto r = SummaryStats::StatRange(SummaryStats::sum_keys);
-                times.bind(x, r.subspan(0, 5));
-                models.bind(x, r.subspan(5));
-            }
-            void addTo(StatsMap& summary) const {
-                summary.add("times", times.toStats());
-                summary.add("models", models.toStats());
-            }
+        struct Item {
+            std::string_view key;
+            StatisticObject (*get)(const Summary*);
         };
-        StatsMap* keys_;
-        StatsMap  problem_;
-        StatsMap  solving_;
-        struct Summary : StatsMap {
-            StepStats step;
+        static auto           getConcurrency(const SharedContext* ctx) -> double { return ctx->concurrency(); }
+        static auto           getWinner(const SharedContext* ctx) -> double { return ctx->winner(); }
+        static constexpr auto getResult(const SolveResult* r) -> double {
+            return static_cast<double>(r->operator SolveResult::Res());
+        }
+        static constexpr auto getSignal(const SolveResult* r) -> double { return static_cast<double>(r->signal); }
+        static constexpr auto getExhausted(const SolveResult* r) -> double {
+            return static_cast<double>(r->exhausted());
+        }
+
+        using StatRange = SpanView<Item>;
+#define LIFT(X) +[](const Summary* s) { return X; }
+        static constexpr Item time_stats[] = {
+            {"total"sv, LIFT(StatisticObject::value(&s->totalTime))},
+            {"cpu"sv, LIFT(StatisticObject::value(&s->cpuTime))},
+            {"solve"sv, LIFT(StatisticObject::value(&s->solveTime))},
+            {"unsat"sv, LIFT(StatisticObject::value(&s->unsatTime))},
+            {"sat"sv, LIFT(StatisticObject::value(&s->satTime))},
+        };
+        static constexpr Item model_stats[] = {
+            {"enumerated"sv, LIFT(StatisticObject::value(&s->numEnum))},
+            {"optimal"sv, LIFT(StatisticObject::value(&s->numOptimal))},
+        };
+        static constexpr Item result_stats[] = {
+            {"call"sv, LIFT(StatisticObject::value(&s->step))},
+            {"result"sv, LIFT(StatisticObject::value<getResult>(&s->result))},
+            {"signal"sv, LIFT(StatisticObject::value<getSignal>(&s->result))},
+            {"exhausted"sv, LIFT(StatisticObject::value<getExhausted>(&s->result))},
+            {"concurrency"sv, LIFT(StatisticObject::value<getConcurrency>(&s->facade->ctx))},
+            {"winner"sv, LIFT(StatisticObject::value<getWinner>(&s->facade->ctx))},
+        };
+#undef LIFT
+        struct StatsObject {
+            explicit StatsObject(const Summary* s = nullptr, StatRange r = {}) : stats(s), range(r) {}
+            [[nodiscard]] constexpr auto size() const -> uint32_t { return size32(range); }
+            [[nodiscard]] constexpr auto key(uint32_t i) const -> std::string_view {
+                POTASSCO_CHECK(i < size(), ERANGE);
+                return range[i].key;
+            }
+            [[nodiscard]] constexpr auto at(std::string_view key) const -> StatisticObject {
+                auto it = std::ranges::find_if(range, [&](const Item& s) { return s.key == key; });
+                POTASSCO_CHECK(it != range.end(), ERANGE);
+                return it->get(stats);
+            }
+            const Summary* stats{nullptr};
+            StatRange      range;
+        };
+        struct SummaryStats {
+            static constexpr std::string_view extra_keys[] = {"times"sv, "models"sv, "costs"sv, "lower"sv};
+            //
+            void bind(const Summary& s) {
+                times  = StatsObject(&s, time_stats);
+                models = StatsObject(&s, model_stats);
+                result = StatsObject(&s, result_stats);
+            }
+            [[nodiscard]] constexpr auto size() const -> uint32_t { return result.size() + size32(extra_keys); }
+            [[nodiscard]] constexpr auto key(uint32_t i) const -> std::string_view {
+                POTASSCO_CHECK(i < size(), ERANGE);
+                return i < size32(result) ? result.key(i) : extra_keys[i - size32(result)];
+            }
+            [[nodiscard]] constexpr auto at(std::string_view key) const -> StatisticObject {
+                if (auto it = std::ranges::find(extra_keys, key); it != std::end(extra_keys)) {
+                    switch (key[0]) {
+                        case 't': return StatisticObject::map(&times);
+                        case 'm': return StatisticObject::map(&models);
+                        case 'c': return StatisticObject::array<&BoundsArray::getUpper>(&bounds);
+                        default : return StatisticObject::array<&BoundsArray::getLower>(&bounds);
+                    }
+                }
+                return result.at(key);
+            }
+            // NOTE: In Clingo issue #242, we decided to always expose the bounds of any minimize statement even if
+            //       they are not relevant. This is deliberately different from the costs()/lower() view provided by
+            //       ClaspFacade::Summary.
+            void updateBounds(const SolveData* data) {
+                const auto* minimizer = data ? data->minimizer() : nullptr;
+                const auto  numBounds = minimizer ? minimizer->numRules() : 0u;
+                auto&       values    = bounds.data;
+                values.resize(std::max(numBounds, size32(values)));
+                static constexpr auto no_bound  = std::numeric_limits<double>::quiet_NaN();
+                static constexpr auto max_bound = SharedMinimizeData::maxBound();
+                static constexpr auto toDouble  = [](Wsum_t b) {
+                    return b != max_bound ? static_cast<double>(b) : std::numeric_limits<double>::infinity();
+                };
+                for (auto level : irange(size32(values))) {
+                    if (level < numBounds) {
+                        assert(minimizer);
+                        if (not values[level]) {
+                            values[level] = new BoundsArray::Bound;
+                        }
+                        auto u               = minimizer->sum(level);
+                        auto l               = minimizer->lower(level);
+                        auto a               = minimizer->adjust(level);
+                        values[level]->lower = toDouble(l + a * (l != max_bound));
+                        values[level]->upper = toDouble(u + a * (u != max_bound));
+                    }
+                    else {
+                        assert(values[level]);
+                        *values[level] = BoundsArray::Bound{no_bound, no_bound};
+                    }
+                }
+                bounds.active = numBounds;
+            }
+            StatsObject times;
+            StatsObject models;
+            StatsObject result;
+            // Array for upper/lower bounds
+            struct BoundsArray {
+                struct Bound {
+                    double lower{};
+                    double upper{};
+                };
+                using value_type = Bound*;
+                static double get(const double* val) {
+                    POTASSCO_CHECK(not std::isnan(*val), ERANGE, "Expired key");
+                    return *val;
+                }
+                static auto getUpper(const value_type& val) -> StatisticObject {
+                    return StatisticObject::value<&get>(&val->upper);
+                }
+                static auto getLower(const value_type& val) -> StatisticObject {
+                    return StatisticObject::value<&get>(&val->lower);
+                }
+                explicit BoundsArray() = default;
+                ~BoundsArray() { std::ranges::for_each(data, DeleteObject{}); }
+                [[nodiscard]] auto size() const -> uint32_t { return active; }
+                [[nodiscard]] auto at(uint32_t i) const -> const value_type& {
+                    POTASSCO_CHECK(i < size(), ERANGE, "Invalid key");
+                    return data[i];
+                }
+                PodVector_t<value_type> data;
+                uint32_t                active{0};
+            };
+            BoundsArray bounds;
         } summary_;
-        struct Accu : StatsMap {
-            StepStats step;
-            StatsMap  solving;
-        };
-        std::unique_ptr<Accu> accu_;
+        struct Accu {
+            void bind(const Summary& s) {
+                times  = StatsObject(&s, time_stats);
+                models = StatsObject(&s, model_stats);
+            }
+            StatsObject times;
+            StatsObject models;
+            Key_t       solving{0};
+        } accu_;
+        Key_t problem_{0};
+        Key_t solving_{0};
     };
     ClingoView*                 getClingo();
     [[nodiscard]] Asp::LpStats* lp() const { return lp_.get(); }
 
 private:
-    using SolverVec   = StatsVec<SolverStats>;
+    static auto getStats(const TaggedPtr<SolverStats>& x) -> StatisticObject { return StatisticObject::map(x.get()); }
+    static auto getAccu(const TaggedPtr<SolverStats>& x) -> StatisticObject {
+        assert(x->multi);
+        return StatisticObject::map(x->multi);
+    }
+    using SolverVec   = PodVector_t<TaggedPtr<SolverStats>>;
     using LpStatsPtr  = std::unique_ptr<Asp::LpStats>;
     using TesterStats = PrgDepGraph::NonHcfStats;
     std::unique_ptr<ClingoView> clingo_; // new clingo stats interface
     ClaspFacade*                self_;
     LpStatsPtr                  lp_;              // level 0 and asp
     SolverStats                 solvers_;         // level 0
-    SolverVec                   solver_;          // level > 1
-    SolverVec                   accu_;            // level > 1 and incremental
+    SolverVec                   solver_;          // level > 1 (maintains accu if incremental)
     TesterStats*                tester_{nullptr}; // level > 0 and nonhcfs
     uint32_t                    level_{0};        // active stats level
 };
@@ -689,7 +736,7 @@ void ClaspFacade::Statistics::initLevel(uint32_t level) {
 void ClaspFacade::Statistics::start(uint32_t level) {
     // cleanup previous state
     solvers_.reset();
-    solver_.reset();
+    for (auto& p : solver_) { p->reset(); }
     if (tester_) {
         tester_->startStep(self_->config()->testerConfig() ? self_->config()->testerConfig()->context().stats : 0);
     }
@@ -700,19 +747,20 @@ void ClaspFacade::Statistics::start(uint32_t level) {
     }
     if (level > 1 && solver_.size() < self_->ctx.concurrency()) {
         auto newIdx = irange(size32(solver_), self_->ctx.concurrency());
-        solver_.growTo(self_->ctx.concurrency());
-        if (incremental()) {
-            accu_.growTo(size32(solver_));
-            for (auto i : newIdx) {
-                solver_[i]        = new SolverStats();
-                accu_[i]          = new SolverStats();
-                solver_[i]->multi = accu_[i];
+        solver_.reserve(self_->ctx.concurrency());
+        for (auto i : newIdx) {
+            solver_.push_back(TaggedPtr{&self_->ctx.solverStats(i)});
+            if (incremental()) {
+                solver_.back()        = TaggedPtr{std::true_type{}, new SolverStats{}};
+                solver_.back()->multi = new SolverStats{};
             }
+            assert(solver_.back().any() == incremental());
         }
-        else {
-            solver_.release();
-            for (auto i : newIdx) { solver_[i] = &self_->ctx.solverStats(i); }
-        }
+    }
+}
+void ClaspFacade::Statistics::freeze() {
+    if (clingo_) {
+        clingo_->freeze(true);
     }
 }
 void ClaspFacade::Statistics::end() {
@@ -727,16 +775,8 @@ void ClaspFacade::Statistics::end() {
         tester_->endStep();
     }
     if (clingo_) {
+        clingo_->freeze(false);
         clingo_->update(*this);
-    }
-}
-void ClaspFacade::Statistics::addTo(StatsMap& solving, StatsMap* accu) const {
-    solvers_.addTo("solvers", solving, accu);
-    if (not solver_.empty()) {
-        solving.add("solver", solver_.toStats());
-    }
-    if (accu && not accu_.empty()) {
-        accu->add("solver", accu_.toStats());
     }
 }
 void ClaspFacade::Statistics::accept(StatsVisitor& out, bool final) const {
@@ -747,14 +787,17 @@ void ClaspFacade::Statistics::accept(StatsVisitor& out, bool final) const {
             out.visitLogicProgramStats(*lp_);
         }
         out.visitProblemStats(self_->ctx.stats());
-        const SolverVec& solver   = final ? accu_ : solver_;
-        const uint32_t   nThreads = final ? size32(accu_) : self_->ctx.concurrency();
-        const auto       nSolver  = size32(solver);
-        if (const AbstractStatistics::Key_t userKey = clingo_ ? clingo_->user(final) : 0) {
-            out.visitExternalStats(clingo_->getObject(userKey));
+        if (clingo_) {
+            clingo_->visitUser(final, out);
         }
+        const auto nSolver  = size32(solver_);
+        const auto nThreads = final ? nSolver : self_->ctx.concurrency();
         if (nThreads > 1 && nSolver > 1 && out.visitThreads(StatsVisitor::enter)) {
-            for (auto i : irange(std::min(nSolver, nThreads))) { out.visitThread(i, *solver[i]); }
+            for (auto i : irange(std::min(nSolver, nThreads))) {
+                POTASSCO_ASSERT(solver_[i]);
+                auto& stats = not final || not solver_[i]->multi ? *solver_[i] : *solver_[i]->multi;
+                out.visitThread(i, stats);
+            }
             out.visitThreads(StatsVisitor::leave);
         }
         out.visitGenerator(StatsVisitor::leave);
@@ -772,46 +815,47 @@ ClaspFacade::Statistics::ClingoView* ClaspFacade::Statistics::getClingo() {
     return clingo_.get();
 }
 ClaspFacade::Statistics::ClingoView::ClingoView(const ClaspFacade& f) {
-    keys_ = makeRoot();
-    summary_.add("call", StatisticObject::value(&f.step_.step));
-    summary_.add("result", StatisticObject::value<SolveResult, c_get_result>(&f.step_.result));
-    summary_.add("signal", StatisticObject::value<SolveResult, c_get_signal>(&f.step_.result));
-    summary_.add("exhausted", StatisticObject::value<SolveResult, c_get_exhausted>(&f.step_.result));
-    summary_.add("costs", StatisticObject::array(&f.solve_->costs));
-    summary_.add("lower", StatisticObject::array(&f.solve_->lower));
-    summary_.add("concurrency", StatisticObject::value<SharedContext, c_get_concurrency>(&f.ctx));
-    summary_.add("winner", StatisticObject::value<SharedContext, c_get_winner>(&f.ctx));
-    summary_.step.bind(f.step_);
-    summary_.step.addTo(summary_);
+    auto r = ClaspStatistics::root();
+    summary_.bind(f.step_);
+    if (f.incremental()) {
+        accu_.bind(*f.accu_.get());
+    }
+    addObject(r, "summary", StatisticObject::map(&summary_), true);
+    problem_ = ClaspStatistics::add(r, "problem", Type::map);
+    addObject(problem_, "generator", StatisticObject::map(&f.ctx.stats()), true);
     if (f.step_.lpStats()) {
-        problem_.add("lp", StatisticObject::map(f.step_.lpStats()));
+        addObject(problem_, "lp", StatisticObject::map(f.step_.lpStats()), true);
         if (f.incremental()) {
-            problem_.add("lpStep", StatisticObject::map(f.step_.lpStep()));
+            addObject(problem_, "lpStep", StatisticObject::map(f.step_.lpStep()), true);
         }
     }
-    problem_.add("generator", StatisticObject::map(&f.ctx.stats()));
-    keys_->add("problem", problem_.toStats());
-    keys_->add("solving", solving_.toStats());
-    keys_->add("summary", summary_.toStats());
-
-    if (f.incremental()) {
-        accu_ = std::make_unique<Accu>();
-        accu_->step.bind(*f.accu_.get());
-    }
 }
-Potassco::AbstractStatistics::Key_t ClaspFacade::Statistics::ClingoView::user(bool final) const {
-    Key_t key = 0;
-    find(root(), final ? "user_accu" : "user_step", &key);
-    return key;
+void ClaspFacade::Statistics::ClingoView::visitUser(bool final, StatsVisitor& out) const {
+    visitExternal(final ? user_accu_stats : user_step_stats, out);
 }
-void ClaspFacade::Statistics::ClingoView::update(const ClaspFacade::Statistics& stats) {
-    if (stats.level_ > 0 && accu_.get() && keys_->add("accu", accu_->toStats())) {
-        accu_->step.addTo(*accu_);
-        accu_->add("solving", accu_->solving.toStats());
+void ClaspFacade::Statistics::ClingoView::update(const Statistics& stats) {
+    summary_.updateBounds(stats.solveData());
+    if (not solving_) {
+        solving_ = ClaspStatistics::add(root(), "solving", Type::map);
+        addObject(solving_, "solvers", StatisticObject::map(&stats.solvers_), true);
     }
-    stats.addTo(solving_, stats.level_ > 0 && accu_.get() ? &accu_->solving : nullptr);
+    if (stats.level_ > 0 && not accu_.solving && stats.incremental()) {
+        auto accu = ClaspStatistics::add(root(), "accu", Type::map);
+        addObject(accu, "times", StatisticObject::map(&accu_.times));
+        addObject(accu, "models", StatisticObject::map(&accu_.models));
+        if (stats.solvers_.multi) {
+            accu_.solving = ClaspStatistics::add(accu, "solving", Type::map);
+            addObject(accu_.solving, "solvers", StatisticObject::map(stats.solvers_.multi), true);
+        }
+    }
+    if (not stats.solver_.empty()) {
+        addObject(solving_, "solver", StatisticObject::array<&getStats>(&stats.solver_));
+        if (accu_.solving) {
+            addObject(accu_.solving, "solver", StatisticObject::array<&getAccu>(&stats.solver_));
+        }
+    }
     if (stats.tester_) {
-        stats.tester_->addTo(problem_, solving_, stats.level_ > 0 && accu_.get() ? &accu_->solving : nullptr);
+        stats.tester_->accept(*this, problem_, solving_, accu_.solving ? &accu_.solving : nullptr);
     }
 }
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -1175,6 +1219,9 @@ bool ClaspFacade::prepare(EnumMode enumMode) {
 
 ClaspFacade::SolveHandle ClaspFacade::solve(SolveMode p, LitView a, EventHandler* eh) {
     POTASSCO_CHECK_PRE(prepare(), "Solving is not enabled");
+    if (stats_) {
+        stats_->freeze();
+    }
     solve_->active = SolveStrategy::create(p, *this, *solve_->algo.get());
     solve_->active->start(eh, a);
     return SolveHandle(solve_->active);

--- a/src/dependency_graph.cpp
+++ b/src/dependency_graph.cpp
@@ -774,53 +774,50 @@ bool PrgDepGraph::NonHcfComponent::simplify(const Solver& s) const {
 // class PrgDepGraph::NonHcfStats
 /////////////////////////////////////////////////////////////////////////////////////////
 struct PrgDepGraph::NonHcfStats::Data {
-    using ProblemVec = StatsVec<ProblemStats>;
-    using SolverVec  = StatsVec<SolverStats>;
+    using SolverStatsPtr = std::unique_ptr<SolverStats>;
     struct ComponentStats {
-        ProblemVec problem;
-        SolverVec  solvers;
-        SolverVec  accu;
+        static auto getProblem(const ComponentStats* x) -> StatisticObject { return StatisticObject::map(&x->problem); }
+        static auto getSolver(const ComponentStats* x) -> StatisticObject { return StatisticObject::map(&x->solver); }
+        static auto getAccu(const ComponentStats* x) -> StatisticObject { return StatisticObject::map(x->accu.get()); }
+        ProblemStats   problem;
+        SolverStats    solver;
+        SolverStatsPtr accu;
     };
-    Data(uint32_t level, bool inc) : components(level > 1 ? std::make_unique<ComponentStats>() : nullptr) {
+    using Components = PodVector_t<ComponentStats*>;
+    Data(uint32_t level, bool inc) : statsLevel(level) {
         if (inc) {
             accus         = std::make_unique<SolverStats>();
             solvers.multi = accus.get();
         }
     }
+    ~Data() { std::ranges::for_each(components, DeleteObject{}); }
     void addHcc(const NonHcfComponent& c) {
-        assert(components);
-        ProblemVec& hcc    = components->problem;
-        SolverVec&  solver = components->solvers;
-        SolverVec*  accu   = solvers.multi ? &components->accu : nullptr;
-        uint32_t    id     = c.id();
-        if (id >= hcc.size()) {
-            hcc.growTo(id + 1);
-            solver.growTo(id + 1);
-            if (accu) {
-                accu->growTo(id + 1);
+        assert(statsLevel > 1);
+        components.resize(std::max(c.id() + 1, size32(components)), nullptr);
+        if (auto id = c.id(); not components[id]) {
+            auto stats     = std::make_unique<ComponentStats>();
+            stats->problem = c.ctx().stats();
+            if (solvers.multi) {
+                stats->accu         = std::make_unique<SolverStats>();
+                stats->solver.multi = stats->accu.get();
             }
-        }
-        if (not hcc[id]) {
-            hcc[id]    = new ProblemStats(c.ctx().stats());
-            solver[id] = new SolverStats();
-            if (accu) {
-                (*accu)[id]       = new SolverStats();
-                solver[id]->multi = (*accu)[id];
-            }
+            components[id] = stats.release();
         }
     }
     void updateHcc(const NonHcfComponent& c) {
         c.ctx().accuStats(solvers);
-        if (components && c.id() < components->solvers.size()) {
-            POTASSCO_CHECK_PRE(components->solvers[c.id()], "component not added to stats!");
-            c.ctx().accuStats(*components->solvers[c.id()]);
-            components->solvers[c.id()]->flush();
+        if (c.id() < size32(components)) {
+            auto* hcc = components[c.id()];
+            POTASSCO_CHECK_PRE(hcc, "component not added to stats!");
+            c.ctx().accuStats(hcc->solver);
+            hcc->solver.flush();
         }
     }
-    ProblemStats                    hccs;
-    SolverStats                     solvers;
-    std::unique_ptr<ComponentStats> components;
-    std::unique_ptr<SolverStats>    accus;
+    ProblemStats   hccs;
+    SolverStats    solvers;
+    Components     components;
+    SolverStatsPtr accus;
+    uint32_t       statsLevel = 0;
 };
 PrgDepGraph::NonHcfStats::NonHcfStats(PrgDepGraph& g, uint32_t l, bool inc)
     : graph_(&g)
@@ -834,20 +831,25 @@ void PrgDepGraph::NonHcfStats::accept(StatsVisitor& out, bool final) const {
     }
     out.visitProblemStats(data_->hccs);
     out.visitSolverStats(final ? *data_->solvers.multi : data_->solvers);
-    if (data_->components && out.visitHccs(StatsVisitor::enter)) {
-        const Data::SolverVec&  solver = final ? data_->components->accu : data_->components->solvers;
-        const Data::ProblemVec& hcc    = data_->components->problem;
-        for (auto i : irange(hcc)) { out.visitHcc(i, *hcc[i], *solver[i]); }
+    if (not data_->components.empty() && out.visitHccs(StatsVisitor::enter)) {
+        for (const auto [id, stats] : Potassco::enumerate<uint32_t>(data_->components)) {
+            if (stats != nullptr) {
+                assert(not final || stats->solver.multi);
+                out.visitHcc(id, stats->problem, final ? *stats->solver.multi : stats->solver);
+            }
+        }
         out.visitHccs(StatsVisitor::leave);
     }
 }
 void PrgDepGraph::NonHcfStats::startStep(uint32_t statsLevel) {
     data_->solvers.reset();
-    if (data_->components) {
-        data_->components->solvers.reset();
+    for (auto* s : data_->components) {
+        if (s) {
+            s->solver.reset();
+        }
     }
-    if (statsLevel > 1 && not data_->components) {
-        data_->components = std::make_unique<Data::ComponentStats>();
+    if (data_->statsLevel <= 1 && statsLevel > 1) {
+        data_->statsLevel = statsLevel;
         for (auto* hcc : graph_->nonHcfs()) { data_->addHcc(*hcc); }
     }
 }
@@ -857,19 +859,25 @@ void PrgDepGraph::NonHcfStats::endStep() {
 }
 void PrgDepGraph::NonHcfStats::addHcc(const NonHcfComponent& c) {
     data_->hccs.accu(c.ctx().stats());
-    if (data_->components) {
+    if (data_->statsLevel > 1) {
         data_->addHcc(c);
     }
 }
 void PrgDepGraph::NonHcfStats::removeHcc(const NonHcfComponent& c) { data_->updateHcc(c); }
-void PrgDepGraph::NonHcfStats::addTo(StatsMap& problem, StatsMap& solving, StatsMap* accu) const {
-    data_->solvers.addTo("hccs", solving, accu);
-    problem.add("hccs", StatisticObject::map(&data_->hccs));
-    if (data_->components) {
-        problem.add("hcc", data_->components->problem.toStats());
-        solving.add("hcc", data_->components->solvers.toStats());
-        if (accu) {
-            accu->add("hcc", data_->components->accu.toStats());
+void PrgDepGraph::NonHcfStats::accept(ClaspStatistics& stats, ClaspStatistics::Key_t problem,
+                                      ClaspStatistics::Key_t solving, const ClaspStatistics::Key_t* accu) const {
+    constexpr auto keyHccs = std::string_view{"hccs"};
+    stats.addObject(problem, keyHccs, StatisticObject::map(&data_->hccs));
+    stats.addObject(solving, keyHccs, StatisticObject::map(&data_->solvers));
+    if (accu && data_->solvers.multi) {
+        stats.addObject(*accu, keyHccs, StatisticObject::map(data_->solvers.multi));
+    }
+    if (not data_->components.empty()) {
+        constexpr auto keyHcc = std::string_view{"hcc"};
+        stats.addObject(problem, keyHcc, StatisticObject::array<Data::ComponentStats::getProblem>(&data_->components));
+        stats.addObject(solving, keyHcc, StatisticObject::array<Data::ComponentStats::getSolver>(&data_->components));
+        if (accu && data_->solvers.multi) {
+            stats.addObject(*accu, keyHcc, StatisticObject::array<Data::ComponentStats::getAccu>(&data_->components));
         }
     }
 }

--- a/src/logic_program.cpp
+++ b/src/logic_program.cpp
@@ -43,38 +43,33 @@ namespace Clasp::Asp {
 /////////////////////////////////////////////////////////////////////////////////////////
 // Statistics
 /////////////////////////////////////////////////////////////////////////////////////////
+using namespace std::literals;
 #define RK(x) RuleStats::x
-const char* RuleStats::toStr(unsigned k) {
+auto RuleStats::toStr(unsigned k) -> std::string_view {
     POTASSCO_ASSERT(k <= numKeys(), "Invalid key");
     switch (k) {
-        case normal   : return "Normal";
-        case choice   : return "Choice";
-        case minimize : return "Minimize";
-        case acyc     : return "Acyc";
-        case heuristic: return "Heuristic";
-        default       : return "None";
+        case normal   : return "Normal"sv;
+        case choice   : return "Choice"sv;
+        case minimize : return "Minimize"sv;
+        case acyc     : return "Acyc"sv;
+        case heuristic: return "Heuristic"sv;
+        default       : return "None"sv;
     }
 }
-uint32_t    RuleStats::sum() const { return std::accumulate(key, key + numKeys(), 0u); }
-const char* BodyStats::toStr(unsigned t) {
+uint32_t RuleStats::sum() const { return std::accumulate(key, key + numKeys(), 0u); }
+auto     BodyStats::toStr(unsigned t) -> std::string_view {
     POTASSCO_ASSERT(t < numKeys(), "Invalid body type!");
     switch (t) {
-        default                            : return "Normal";
-        case to_underlying(BodyType::count): return "Count";
-        case to_underlying(BodyType::sum)  : return "Sum";
+        default                            : return "Normal"sv;
+        case to_underlying(BodyType::count): return "Count"sv;
+        case to_underlying(BodyType::sum)  : return "Sum"sv;
     }
 }
 uint32_t BodyStats::sum() const { return std::accumulate(key, key + numKeys(), 0u); }
 
 namespace {
-template <unsigned I>
-double sumBodies(const LpStats* self) {
-    return self->bodies[I].sum();
-}
-template <unsigned I>
-double sumRules(const LpStats* self) {
-    return self->rules[I].sum();
-}
+double sum(const BodyStats* bs) { return bs->sum(); }
+double sum(const RuleStats* rs) { return rs->sum(); }
 double sumEqs(const LpStats* self) { return self->eqs(); }
 } // namespace
 #define LP_STATS(APPLY)                                                                                                \
@@ -82,8 +77,8 @@ double sumEqs(const LpStats* self) { return self->eqs(); }
     APPLY("atoms_aux", VALUE(auxAtoms))                                                                                \
     APPLY("disjunctions", VALUE(disjunctions[0]))                                                                      \
     APPLY("disjunctions_non_hcf", VALUE(disjunctions[1]))                                                              \
-    APPLY("bodies", FUNC(sumBodies<0>))                                                                                \
-    APPLY("bodies_tr", FUNC(sumBodies<1>))                                                                             \
+    APPLY("bodies", SUM(bodies[0]))                                                                                    \
+    APPLY("bodies_tr", SUM(bodies[1]))                                                                                 \
     APPLY("sum_bodies", VALUE(bodies[0][to_underlying(BodyType::sum)]))                                                \
     APPLY("sum_bodies_tr", VALUE(bodies[1][to_underlying(BodyType::sum)]))                                             \
     APPLY("count_bodies", VALUE(bodies[0][to_underlying(BodyType::count)]))                                            \
@@ -92,19 +87,19 @@ double sumEqs(const LpStats* self) { return self->eqs(); }
     APPLY("sccs_non_hcf", VALUE(nonHcfs))                                                                              \
     APPLY("gammas", VALUE(gammas))                                                                                     \
     APPLY("ufs_nodes", VALUE(ufsNodes))                                                                                \
-    APPLY("rules", FUNC(sumRules<0>))                                                                                  \
+    APPLY("rules", SUM(rules[0]))                                                                                      \
     APPLY("rules_normal", VALUE(rules[0][RK(normal)]))                                                                 \
     APPLY("rules_choice", VALUE(rules[0][RK(choice)]))                                                                 \
     APPLY("rules_minimize", VALUE(rules[0][RK(minimize)]))                                                             \
     APPLY("rules_acyc", VALUE(rules[0][RK(acyc)]))                                                                     \
     APPLY("rules_heuristic", VALUE(rules[0][RK(heuristic)]))                                                           \
-    APPLY("rules_tr", FUNC(sumRules<1>))                                                                               \
+    APPLY("rules_tr", SUM(rules[1]))                                                                                   \
     APPLY("rules_tr_normal", VALUE(rules[1][RK(normal)]))                                                              \
     APPLY("rules_tr_choice", VALUE(rules[1][RK(choice)]))                                                              \
     APPLY("rules_tr_minimize", VALUE(rules[1][RK(minimize)]))                                                          \
     APPLY("rules_tr_acyc", VALUE(rules[1][RK(acyc)]))                                                                  \
     APPLY("rules_tr_heuristic", VALUE(rules[1][RK(heuristic)]))                                                        \
-    APPLY("eqs", FUNC(sumEqs))                                                                                         \
+    APPLY("eqs", FUN(sumEqs))                                                                                          \
     APPLY("eqs_atom", VALUE(eqs_[+VarType::atom - 1]))                                                                 \
     APPLY("eqs_body", VALUE(eqs_[+VarType::body - 1]))                                                                 \
     APPLY("eqs_other", VALUE(eqs_[+VarType::hybrid - 1]))
@@ -136,17 +131,18 @@ static constexpr std::string_view lp_stats_s[] = {
     LP_STATS(KEY)
 #undef KEY
 };
-uint32_t         LpStats::size() { return size32(lp_stats_s); }
-std::string_view LpStats::key(uint32_t i) {
+auto LpStats::size() -> uint32_t { return size32(lp_stats_s); }
+auto LpStats::key(uint32_t i) -> std::string_view {
     POTASSCO_CHECK(i < size(), ERANGE);
     return lp_stats_s[i];
 }
-StatisticObject LpStats::at(std::string_view k) const {
+auto LpStats::at(std::string_view k) const -> StatisticObject {
 #define MAP_IF(x, A)                                                                                                   \
     if (k == (x))                                                                                                      \
         return A;
 #define VALUE(X) StatisticObject::value(&(X))
-#define FUNC(F)  StatisticObject::value<LpStats, F>(this)
+#define SUM(X)   StatisticObject::value<static_cast<double (*)(decltype(&this->X))>(sum)>(&this->X)
+#define FUN(F)   StatisticObject::value<F>(this)
     LP_STATS(MAP_IF)
 #undef VALUE
 #undef FUNC

--- a/src/shared_context.cpp
+++ b/src/shared_context.cpp
@@ -50,15 +50,15 @@ static constexpr std::string_view stats_s[] = {
     PS_STATS(KEY)
 #undef KEY
 };
-uint32_t         ProblemStats::size() { return size32(stats_s); }
-std::string_view ProblemStats::key(uint32_t i) {
+auto ProblemStats::size() -> uint32_t { return size32(stats_s); }
+auto ProblemStats::key(uint32_t i) -> std::string_view {
     POTASSCO_CHECK(i < size(), ERANGE);
     return stats_s[i];
 }
-StatisticObject ProblemStats::at(std::string_view key) const {
+auto ProblemStats::at(std::string_view k) const -> StatisticObject {
 #define VALUE(X) StatisticObject::value(&(X))
 #define APPLY(x, y)                                                                                                    \
-    if (key == #x)                                                                                                     \
+    if (k == #x)                                                                                                       \
         return y;
     PS_STATS(APPLY)
     POTASSCO_CHECK(false, ERANGE);

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -1894,7 +1894,7 @@ Solver::DBInfo Solver::reduceSort(uint32_t maxR, const CmpScore& sc) {
     heap.reserve(maxR = std::min(maxR, size32(learnts_)));
     DBInfo res{};
     // Find and tag maxR lowest elements.
-    for (auto [idx, con] : Potassco::enumerate(learnts_)) {
+    for (auto [idx, con] : Potassco::enumerate<uint32_t>(learnts_)) {
         auto data = ConData{idx, con->activity()};
         if (auto pinned = sc.isGlue(data.second), locked = con->locked(*this);
             locked || pinned || sc.isFrozen(data.second)) {

--- a/src/solver_types.cpp
+++ b/src/solver_types.cpp
@@ -40,59 +40,48 @@ namespace Clasp {
 #define CLASP_STAT_ACCU(m, k, a, accu) accu;
 #define CLASP_STAT_KEY(m, k, a, accu)  k,
 #define CLASP_STAT_GET(m, k, a, accu)                                                                                  \
-    if (key == k) {                                                                                                    \
+    if (key == (k)) {                                                                                                  \
         return a;                                                                                                      \
     }
 // NOLINTBEGIN(*-macro-parentheses)
-#define CLASP_DEFINE_ISTATS_COMMON(T, STATS, name)                                                                     \
+#define CLASP_DEFINE_ISTATS(T, STATS, name)                                                                            \
     static constexpr std::string_view const T##_s[] = {STATS(CLASP_STAT_KEY, NO_ARG, NO_ARG)};                         \
-    uint32_t                                T::size() { return size32(T##_s); }                                        \
-    std::string_view                        T::key(uint32_t i) {                                                       \
-        POTASSCO_CHECK(i < size(), ERANGE);                                                     \
-        return T##_s[i];                                                                        \
+    auto                                    T::size() -> uint32_t { return size32(T##_s); }                            \
+    auto                                    T::key(uint32_t i) -> std::string_view {                                   \
+        POTASSCO_CHECK(i < size(), ERANGE);                                         \
+        return T##_s[i];                                                            \
     }                                                                                                                  \
-    void T::accu(const T& o) { STATS(CLASP_STAT_ACCU, (*this), o); }
+    void T::accu(const T& o) { STATS(CLASP_STAT_ACCU, (*this), o); }                                                   \
+    auto T::at(std::string_view key) const -> StatisticObject {                                                        \
+        using StatsType [[maybe_unused]] = T;                                                                          \
+        STATS(CLASP_STAT_GET, NO_ARG, NO_ARG);                                                                         \
+        POTASSCO_FAIL(ERANGE);                                                                                         \
+    }
 // NOLINTEND(*-macro-parentheses)
 /////////////////////////////////////////////////////////////////////////////////////////
-// CoreStats
+// CoreStats/JumpStats/ExtendedStats
 /////////////////////////////////////////////////////////////////////////////////////////
-CLASP_DEFINE_ISTATS_COMMON(CoreStats, CLASP_CORE_STATS, "core")
-StatisticObject CoreStats::at(std::string_view key) const {
-#define VALUE(X) StatisticObject::value(&X) // NOLINT(*-macro-parentheses)
-    CLASP_CORE_STATS(CLASP_STAT_GET, NO_ARG, NO_ARG);
-#undef VALUE
-    POTASSCO_CHECK(false, ERANGE);
-}
-/////////////////////////////////////////////////////////////////////////////////////////
-// JumpStats
-/////////////////////////////////////////////////////////////////////////////////////////
+#define VALUE(X)      StatisticObject::value(&X) // NOLINT(*-macro-parentheses)
+#define MEM_FUN(X)    StatisticObject::value<X##_thunk>(this)
+#define MAP(X)        StatisticObject::map(&X) // NOLINT(*-macro-parentheses)
 #define MAX_MEM(X, Y) X = std::max((X), (Y))
-CLASP_DEFINE_ISTATS_COMMON(JumpStats, CLASP_JUMP_STATS, "jumps")
-#undef MAX_MEM
-StatisticObject JumpStats::at(std::string_view key) const {
-#define VALUE(X) StatisticObject::value(&X) // NOLINT(*-macro-parentheses)
-    CLASP_JUMP_STATS(CLASP_STAT_GET, NO_ARG, NO_ARG);
-#undef VALUE
-    POTASSCO_CHECK(false, ERANGE);
-}
-/////////////////////////////////////////////////////////////////////////////////////////
-// ExtendedStats
-/////////////////////////////////////////////////////////////////////////////////////////
-CLASP_DEFINE_ISTATS_COMMON(ExtendedStats, CLASP_EXTENDED_STATS, "extra")
 namespace {
 double lemmas_thunk(const ExtendedStats* self) { return static_cast<double>(self->lemmas()); }
 double learntLits_thunk(const ExtendedStats* self) { return static_cast<double>(self->learntLits()); }
 } // namespace
-StatisticObject ExtendedStats::at(std::string_view key) const {
-#define VALUE(X)   StatisticObject::value(&X) // NOLINT(*-macro-parentheses)
-#define MEM_FUN(X) StatisticObject::value<ExtendedStats, X##_thunk>(this)
-#define MAP(X)     StatisticObject::map(&X) // NOLINT(*-macro-parentheses)
-    CLASP_EXTENDED_STATS(CLASP_STAT_GET, NO_ARG, NO_ARG);
+CLASP_DEFINE_ISTATS(CoreStats, CLASP_CORE_STATS, "core")
+CLASP_DEFINE_ISTATS(JumpStats, CLASP_JUMP_STATS, "jumps")
+CLASP_DEFINE_ISTATS(ExtendedStats, CLASP_EXTENDED_STATS, "extra")
+#undef NO_ARG
 #undef VALUE
 #undef MEM_FUN
 #undef MAP
-    POTASSCO_CHECK(false, ERANGE);
-}
+#undef MAX_MEM
+#undef CLASP_STAT_ACCU
+#undef CLASP_STAT_KEY
+#undef CLASP_STAT_GET
+#undef CLASP_DEFINE_ISTATS
+#undef CLASP_DEFINE_STATS_AT
 /////////////////////////////////////////////////////////////////////////////////////////
 // SolverStats
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -134,29 +123,17 @@ void SolverStats::swapStats(SolverStats& o) {
     std::swap(static_cast<CoreStats&>(*this), static_cast<CoreStats&>(o));
     std::swap(extra, o.extra);
 }
-uint32_t         SolverStats::size() const { return CoreStats::size() + (extra != nullptr); }
-std::string_view SolverStats::key(uint32_t i) const {
+auto SolverStats::size() const -> uint32_t { return CoreStats::size() + (extra != nullptr); }
+auto SolverStats::key(uint32_t i) const -> std::string_view {
     POTASSCO_CHECK(i < size(), ERANGE);
     return i < CoreStats::size() ? CoreStats::key(i) : "extra";
 }
-
-StatisticObject SolverStats::at(std::string_view k) const {
+auto SolverStats::at(std::string_view k) const -> StatisticObject {
     if (extra && k.starts_with("extra") && (k.length() == 5 || k[5] == '.')) {
         return k.length() == 5 ? StatisticObject::map(extra) : extra->at(k.substr(6));
     }
     return CoreStats::at(k);
 }
-void SolverStats::addTo(std::string_view key, StatsMap& solving, StatsMap* accu) const { // NOLINT(*-no-recursion)
-    solving.add(key, StatisticObject::map(this));
-    if (accu && this->multi) {
-        multi->addTo(key, *accu, nullptr);
-    }
-}
-#undef NO_ARG
-#undef CLASP_STAT_ACCU
-#undef CLASP_STAT_KEY
-#undef CLASP_STAT_GET
-#undef CLASP_DEFINE_ISTATS_COMMON
 /////////////////////////////////////////////////////////////////////////////////////////
 // ClauseHead
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/statistics.cpp
+++ b/src/statistics.cpp
@@ -26,344 +26,14 @@
 #include <clasp/util/misc_types.h>
 
 #include <potassco/error.h>
+#include <potassco/match_basic_types.h>
 #include <potassco/utils.h>
 
 #include <cctype>
 #include <cstring>
-#include <stdexcept>
 #include <unordered_set>
 
 namespace Clasp {
-/////////////////////////////////////////////////////////////////////////////////////////
-// StatisticObject
-/////////////////////////////////////////////////////////////////////////////////////////
-StatisticObject::V      StatisticObject::s_empty_(+[](const void*) { return 0.0; });
-StatisticObject::RegVec StatisticObject::s_types_(1, &StatisticObject::s_empty_);
-
-StatisticObject::StatisticObject() : handle_(0) {}
-StatisticObject::StatisticObject(uint64_t h) : handle_(h) {}
-StatisticObject::StatisticObject(const void* obj, uint32_t type) {
-    handle_  = static_cast<uint64_t>(type) << 48;
-    handle_ |= static_cast<uint64_t>(reinterpret_cast<uintptr_t>(obj));
-}
-const void* StatisticObject::self() const {
-    static constexpr auto ptr_mask = Potassco::bit_max<uint64_t>(48);
-    return reinterpret_cast<const void*>(static_cast<uintptr_t>(handle_ & ptr_mask));
-}
-std::size_t StatisticObject::typeId() const { return static_cast<uint32_t>(handle_ >> 48); }
-auto        StatisticObject::tid() const -> const I* { return s_types_.at(static_cast<uint32_t>(handle_ >> 48)); }
-auto        StatisticObject::type() const -> Type { return handle_ ? tid()->type : Type::value; }
-uint32_t    StatisticObject::size() const {
-    switch (type()) {
-        default         : POTASSCO_ASSERT_NOT_REACHED("invalid object");
-        case Type::value: return 0;
-        case Type::array: return tid()->as<A>()->size(self());
-        case Type::map  : return tid()->as<M>()->size(self());
-    }
-}
-std::string_view StatisticObject::key(uint32_t i) const {
-    POTASSCO_CHECK_PRE(type() == Type::map, "type error");
-    return tid()->as<M>()->key(self(), i);
-}
-StatisticObject StatisticObject::at(std::string_view k) const {
-    POTASSCO_CHECK_PRE(type() == Type::map, "type error");
-    return tid()->as<M>()->at(self(), k);
-}
-StatisticObject StatisticObject::operator[](uint32_t i) const {
-    POTASSCO_CHECK_PRE(type() == Type::array, "type error");
-    return tid()->as<A>()->at(self(), i);
-}
-double StatisticObject::value() const {
-    POTASSCO_CHECK_PRE(type() == Type::value, "type error");
-    return tid()->as<V>()->value(self());
-}
-std::size_t     StatisticObject::hash() const { return std::hash<uint64_t>()(toRep()); }
-uint64_t        StatisticObject::toRep() const { return handle_; }
-StatisticObject StatisticObject::fromRep(uint64_t x) {
-    StatisticObject r(x);
-    POTASSCO_CHECK_PRE(r.tid() != nullptr && not Potassco::test_any(reinterpret_cast<uintptr_t>(r.self()), 3u),
-                       "invalid key");
-    return r;
-}
-/////////////////////////////////////////////////////////////////////////////////////////
-// StatsMap
-/////////////////////////////////////////////////////////////////////////////////////////
-StatisticObject StatsMap::at(std::string_view k) const {
-    const auto* o = find(k);
-    POTASSCO_CHECK(o, ERANGE, "StatsMap::at with key '%" PRIsv "'", PRI_SV(k));
-    return *o;
-}
-const StatisticObject* StatsMap::find(std::string_view k) const {
-    auto it = std::ranges::find_if(keys_, [k](const auto& p) { return p.first == k; });
-    return it != keys_.end() ? &it->second : nullptr;
-}
-bool StatsMap::add(std::string_view k, const StatisticObject& o) {
-    return not find(k) && (keys_.push_back(MapType::value_type(k, o)), true);
-}
-void StatsMap::push(std::string_view k, const StatisticObject& o) { keys_.push_back(MapType::value_type(k, o)); }
-/////////////////////////////////////////////////////////////////////////////////////////
-// ClaspStatistics
-/////////////////////////////////////////////////////////////////////////////////////////
-struct ClaspStatistics::Impl {
-    using KeySet    = std::unordered_set<uint64_t>;
-    using StringSet = std::unordered_set<Potassco::ConstString, std::hash<Potassco::ConstString>, std::equal_to<>>;
-    struct Map : StatsMap {
-        static const std::size_t id_s;
-    };
-    struct Arr : PodVector_t<StatisticObject> {
-        static const std::size_t id_s;
-
-        [[nodiscard]] StatisticObject toStats() const { return StatisticObject::array(this); }
-    };
-    struct Val {
-        static const std::size_t id_s;
-
-        Val(double d) : value(d) {} // NOLINT(*-explicit-constructor)
-        explicit operator double() const { return value; }
-        double   value;
-    };
-
-    Impl() = default;
-
-    ~Impl() {
-        for (auto key : objects) { destroyIfWritable(key); }
-    }
-
-    Key_t add(const StatisticObject& o) { return *objects.insert(o.toRep()).first; }
-
-    static void destroyIfWritable(Key_t k) {
-        try {
-            StatisticObject obj = StatisticObject::fromRep(k);
-            if (size_t typeId = obj.typeId(); typeId == Map::id_s) {
-                delete static_cast<const Map*>(obj.self());
-            }
-            else if (typeId == Arr::id_s) {
-                delete static_cast<const Arr*>(obj.self());
-            }
-            else if (typeId == Val::id_s) {
-                delete static_cast<const Val*>(obj.self());
-            }
-        }
-        catch (const std::exception&) {
-            POTASSCO_ASSERT_NOT_REACHED("unexpected exception");
-        }
-    }
-    StatisticObject newWritable(Type type) {
-        StatisticObject obj;
-        switch (type) {
-            case Type::value: obj = StatisticObject::value(new Val(0.0)); break;
-            case Type::map  : obj = StatisticObject::map(new Map()); break;
-            case Type::array: obj = StatisticObject::array(new Arr()); break;
-            default         : POTASSCO_ASSERT_NOT_REACHED("unsupported statistic object type");
-        }
-        add(obj);
-        return obj;
-    }
-
-    bool writable(Key_t k) const {
-        auto typeId = StatisticObject::fromRep(k).typeId();
-        return (typeId == Map::id_s || typeId == Arr::id_s || typeId == Val::id_s) && objects.contains(k);
-    }
-
-    bool remove(const StatisticObject& o) {
-        if (auto it = objects.find(o.toRep()); it != objects.end() && not emptyKey(*it)) {
-            destroyIfWritable(*it);
-            objects.erase(it);
-            return true;
-        }
-        return false;
-    }
-
-    StatisticObject get(Key_t k) const {
-        POTASSCO_CHECK_PRE(objects.contains(k), "invalid key");
-        return StatisticObject::fromRep(k);
-    }
-
-    template <class T>
-    T* writable(Key_t k) const {
-        StatisticObject obj = StatisticObject::fromRep(k);
-        POTASSCO_CHECK_PRE(writable(k), "key not writable");
-        POTASSCO_CHECK_PRE(T::id_s == obj.typeId(), "type error");
-        return static_cast<T*>(const_cast<void*>(obj.self()));
-    }
-
-    void update(const StatisticObject& obj) {
-        KeySet seen;
-        visit(obj, seen);
-        if (objects.size() != seen.size()) {
-            for (auto o : objects) {
-                if (not seen.contains(o)) {
-                    destroyIfWritable(o);
-                }
-            }
-            objects.swap(seen);
-        }
-    }
-
-    void visit(const StatisticObject& obj, KeySet& visited) {
-        if (auto it = objects.find(obj.toRep()); it == objects.end() || not visited.insert(*it).second) {
-            return;
-        }
-        switch (obj.type()) {
-            case Type::map:
-                for (auto i : irange(obj)) { visit(obj.at(obj.key(i)), visited); }
-                break;
-            case Type::array:
-                for (auto i : irange(obj)) { visit(obj[i], visited); }
-                break;
-            default: break;
-        }
-    }
-
-    std::string_view string(std::string_view s) {
-        auto view = std::string_view{s};
-        auto it   = strings.find(view);
-        if (it != strings.end()) {
-            return it->c_str();
-        }
-        return strings.insert(it, Potassco::ConstString(view))->c_str();
-    }
-    static Key_t key(const StatisticObject& obj) { return static_cast<Key_t>(obj.toRep()); }
-    static bool  emptyKey(Key_t k) { return k == 0; }
-
-    KeySet    objects;
-    StringSet strings;
-    Key_t     root{0};
-    uint32_t  gc{0};
-    uint32_t  rem{0};
-};
-const std::size_t ClaspStatistics::Impl::Map::id_s = StatisticObject::map(static_cast<Map*>(nullptr)).typeId();
-const std::size_t ClaspStatistics::Impl::Arr::id_s = StatisticObject::array(static_cast<Arr*>(nullptr)).typeId();
-const std::size_t ClaspStatistics::Impl::Val::id_s = StatisticObject::value(static_cast<Val*>(nullptr)).typeId();
-constexpr bool    isPath(std::string_view k) { return k.find('.') != std::string_view::npos; }
-constexpr std::string_view popNext(std::string_view& path) {
-    auto ep = path.find('.');
-    auto r  = path.substr(0, ep);
-    path.remove_prefix(std::min(r.length() + 1, path.length()));
-    return r; // NOLINT
-}
-ClaspStatistics::ClaspStatistics() : impl_(std::make_unique<Impl>()) {}
-ClaspStatistics::ClaspStatistics(StatisticObject root) : ClaspStatistics() { impl_->root = impl_->add(root); }
-ClaspStatistics::~ClaspStatistics() = default;
-auto   ClaspStatistics::getObject(Key_t k) const -> StatisticObject { return impl_->get(k); }
-auto   ClaspStatistics::root() const -> Key_t { return impl_->root; }
-auto   ClaspStatistics::type(Key_t key) const -> Type { return getObject(key).type(); }
-size_t ClaspStatistics::size(Key_t key) const { return getObject(key).size(); }
-bool   ClaspStatistics::writable(Key_t key) const { return impl_->writable(key); }
-auto ClaspStatistics::at(Key_t arrK, size_t index) const -> Key_t { return impl_->add(getObject(arrK)[toU32(index)]); }
-auto ClaspStatistics::key(Key_t mapK, size_t i) const -> std::string_view { return getObject(mapK).key(toU32(i)); }
-auto ClaspStatistics::get(Key_t mapK, std::string_view path) const -> Key_t {
-    return impl_->add(not isPath(path) ? getObject(mapK).at(path) : findObject(mapK, path));
-}
-bool ClaspStatistics::find(Key_t mapK, std::string_view element, Key_t* outKey) const {
-    try {
-        if (not writable(mapK) || isPath(element)) {
-            findObject(mapK, element, outKey);
-            return true;
-        }
-        auto* map = impl_->writable<Impl::Map>(mapK);
-        if (const StatisticObject* obj = map->find(element)) {
-            if (outKey) {
-                *outKey = impl_->add(*obj);
-            }
-            return true;
-        }
-    }
-    catch (const std::exception&) { // NOLINT(*-empty-catch)
-        // fallthrough
-    }
-    return false;
-}
-double ClaspStatistics::value(Key_t key) const { return getObject(key).value(); }
-auto   ClaspStatistics::changeRoot(Key_t newRoot) -> Key_t {
-    auto old    = impl_->root;
-    impl_->root = impl_->add(getObject(newRoot));
-    return old;
-}
-StatsMap* ClaspStatistics::makeRoot() {
-    auto* root  = new Impl::Map();
-    impl_->root = impl_->add(StatisticObject::map(root));
-    return root;
-}
-bool ClaspStatistics::removeStat(const StatisticObject& obj, bool recurse) {
-    bool ret = impl_->remove(obj);
-    if (ret && recurse) {
-        if (obj.type() == Type::map) {
-            for (auto i : irange(obj)) { removeStat(obj.at(obj.key(i)), true); }
-        }
-        else if (obj.type() == Type::array) {
-            for (auto i : irange(obj)) { removeStat(obj[i], true); }
-        }
-    }
-    return ret;
-}
-bool ClaspStatistics::removeStat(Key_t k, bool recurse) {
-    try {
-        return removeStat(impl_->get(k), recurse);
-    }
-    catch (const std::logic_error&) {
-        return false;
-    }
-}
-void ClaspStatistics::update() {
-    if (impl_->root) {
-        impl_->update(getObject(impl_->root));
-    }
-}
-
-static bool getIndex(std::string_view top, uint32_t& idx) {
-    idx = 0;
-    while (not top.empty() && std::isdigit(static_cast<unsigned char>(top.front()))) {
-        idx *= 10;
-        idx += static_cast<unsigned>(top.front() - '0');
-        top.remove_prefix(1);
-    }
-    return top.empty();
-}
-
-StatisticObject ClaspStatistics::findObject(Key_t root, std::string_view path, Key_t* res) const {
-    auto o = getObject(root);
-    auto t = o.type();
-    for (auto parent = path; not path.empty();) {
-        auto top = popNext(path);
-        if (t == Type::map) {
-            o = o.at(top);
-        }
-        else if (uint32_t pos; t == Type::array && getIndex(top, pos)) {
-            o = o[pos];
-        }
-        else {
-            POTASSCO_CHECK(false, ERANGE, "invalid path: '%" PRIsv "' at key '%" PRIsv "'", PRI_SV(parent),
-                           PRI_SV(top));
-        }
-        t = o.type();
-    }
-    POTASSCO_ASSERT(o.toRep() != 0);
-    if (res) {
-        *res = impl_->add(o);
-    }
-    return o;
-}
-auto ClaspStatistics::push(Key_t key, Type type) -> Key_t {
-    auto* arr = impl_->writable<Impl::Arr>(key);
-    auto  obj = impl_->newWritable(type);
-    arr->push_back(obj);
-    return Impl::key(obj);
-}
-auto ClaspStatistics::add(Key_t mapK, std::string_view name, Type type) -> Key_t {
-    auto* map = impl_->writable<Impl::Map>(mapK);
-    if (const StatisticObject* stat = map->find(name)) {
-        POTASSCO_CHECK_PRE(stat->type() == type, "redefinition error");
-        return Impl::key(*stat);
-    }
-    auto stat = impl_->newWritable(type);
-    map->push(impl_->string(name), stat);
-    return Impl::key(stat);
-}
-void ClaspStatistics::set(Key_t key, double value) {
-    auto* val = impl_->writable<Impl::Val>(key);
-    *val      = value;
-}
 /////////////////////////////////////////////////////////////////////////////////////////
 // StatsVisitor
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -377,5 +47,308 @@ void StatsVisitor::visitHcc(uint32_t, const ProblemStats& p, const SolverStats& 
     visitSolverStats(s);
 }
 void StatsVisitor::visitThread(uint32_t, const SolverStats& stats) { visitSolverStats(stats); }
+/////////////////////////////////////////////////////////////////////////////////////////
+// ClaspStatistics
+/////////////////////////////////////////////////////////////////////////////////////////
+struct ClaspStatistics::Impl {
+    using Objects = PodVector_t<StatisticObject>;
+    struct IndirectStatsHash {
+        static constexpr auto mix = sizeof(std::size_t) == 8 ? static_cast<std::size_t>(0x9e3779b97f4a7c15ULL)
+                                                             : static_cast<std::size_t>(0x9e3779b9UL);
 
+        explicit IndirectStatsHash(const Objects* obj) : objects(obj) { POTASSCO_ASSERT(obj != nullptr); }
+        auto operator()(StatisticObject o) const noexcept -> std::size_t {
+            auto h1  = reinterpret_cast<std::size_t>(o.object());
+            auto h2  = reinterpret_cast<std::size_t>(o.typeId());
+            h1      ^= h2 + mix + (h1 << 6) + (h1 >> 2);
+            return h1;
+        }
+        auto operator()(uint32_t idx) const noexcept -> std::size_t { return (*this)(objects->at(idx)); }
+        auto operator()(uint32_t lhs, uint32_t rhs) const noexcept -> std::size_t {
+            return objects->at(lhs) == objects->at(rhs);
+        }
+        const Objects* objects;
+    };
+    using Object2Key = std::unordered_set<uint32_t, IndirectStatsHash, IndirectStatsHash>;
+    using Strings    = std::unordered_set<std::string>;
+    // Distinguished key types - stored in different containers
+    template <Type T, uint32_t N>
+    using Checked_t = std::conditional_t<static_cast<uint32_t>(T) == N, std::integral_constant<uint32_t, N>, void>;
+    enum class KeyType : uint32_t {
+        key_val = Checked_t<Type::value, 0u>::value,
+        key_arr = Checked_t<Type::array, 1u>::value,
+        key_map = Checked_t<Type::map, 2u>::value,
+        key_ext = 3u
+    };
+    //
+    static constexpr auto key_shift = 62u;
+    static constexpr auto keyType(Key_t key) -> KeyType { return static_cast<KeyType>(key >> key_shift); }
+    static constexpr auto keyIdx(Key_t key) -> uint32_t { return static_cast<uint32_t>(key); }
+    static constexpr auto writable(Key_t key) -> bool { return keyType(key) != KeyType::key_ext; }
+    static constexpr auto makeKey(KeyType type, uint32_t idx) -> Key_t {
+        return (static_cast<Key_t>(type) << key_shift) | idx;
+    }
+    // Type representing a user-created (writable) value.
+    struct WritableValue {
+        static constexpr auto key_type = KeyType::key_val;
+        explicit              operator double() const { return d; }
+        explicit              operator StatisticObject() const { return StatisticObject::value(this); }
+        //
+        double d = 0.0;
+    };
+    // Type representing a user-created (writable) map.
+    struct WritableMap {
+        static constexpr auto key_type = KeyType::key_map;
+        explicit WritableMap(Impl& i) : self(&i) {}
+        explicit           operator StatisticObject() const { return StatisticObject::map(this); }
+        [[nodiscard]] auto size() const -> uint32_t { return size32(keys); }
+        [[nodiscard]] auto key(uint32_t i) const -> std::string_view { return keys.at(i).first; }
+        [[nodiscard]] auto at(std::string_view k) const -> StatisticObject { return self->getObject(child(k)); }
+        [[nodiscard]] auto find(std::string_view k) const -> const Key_t* {
+            auto it = std::ranges::find_if(keys, [k](const auto& p) { return p.first == k; });
+            return it != keys.end() ? &it->second : nullptr;
+        }
+        [[nodiscard]] auto child(std::string_view k) const -> Key_t {
+            const auto* key = find(k);
+            POTASSCO_CHECK(key, ERANGE, "WritableMap::at with key '%" PRIsv "'", PRI_SV(k));
+            return *key;
+        }
+        void add(std::string_view n, Key_t k) { keys.push_back(std::pair(n, k)); }
+        using Children = PodVector_t<std::pair<std::string_view, Key_t>>;
+        Impl*    self{};
+        Children keys;
+    };
+    // Type representing a user-created (writable) array.
+    struct WritableArray {
+        static constexpr auto key_type = KeyType::key_arr;
+        explicit WritableArray(Impl& i) : self(&i) {}
+        explicit           operator StatisticObject() const { return StatisticObject::array(this); }
+        [[nodiscard]] auto size() const -> uint32_t { return size32(keys); }
+        [[nodiscard]] auto at(uint32_t i) const -> StatisticObject { return self->getObject(child(i)); }
+        [[nodiscard]] auto child(uint32_t i) const -> Key_t { return keys.at(i); }
+        void               add(Key_t key) { keys.push_back(key); }
+        using Children = PodVector_t<Key_t>;
+        Impl*    self{};
+        Children keys;
+    };
+
+    Impl() {
+        maps.push_back(WritableMap{*this});
+        ext.reserve(64);
+    }
+    ~Impl() {
+        PodVector<WritableArray>::destruct(arrays);
+        PodVector<WritableMap>::destruct(maps);
+    }
+    void               freeze(bool b) { frozen.exchange(b == true); }
+    [[nodiscard]] auto getObject(Key_t key) const -> StatisticObject {
+        static constexpr auto get = [](const auto& container, Key_t k) -> StatisticObject {
+            if (auto idx = keyIdx(k); idx < size32(container)) {
+                return static_cast<StatisticObject>(container[idx]);
+            }
+            throwKey(k);
+        };
+        POTASSCO_CHECK_PRE(not frozen || keyType(key) != KeyType::key_ext, "statistics not (yet) accessible");
+        switch (keyType(key)) {
+            case KeyType::key_ext: return get(ext, key);
+            case KeyType::key_map: return get(maps, key);
+            case KeyType::key_arr: return get(arrays, key);
+            case KeyType::key_val: return get(values, key);
+        }
+        POTASSCO_ASSERT_NOT_REACHED("unexpected key type");
+    }
+    auto addWritable(Type t) -> Key_t {
+        static constexpr auto push = []<typename C>(C& cont, auto&... args) {
+            using T = typename C::value_type;
+            cont.reserve(8);
+            auto idx = size32(cont);
+            cont.push_back(T{args...});
+            return makeKey(T::key_type, idx);
+        };
+        switch (t) {
+            case Type::value: return push(values);
+            case Type::array: return push(arrays, *this);
+            case Type::map  : return push(maps, *this);
+        }
+        POTASSCO_ASSERT_NOT_REACHED("unexpected stats type");
+    }
+    template <typename C>
+    static auto ensureWritable(const C& cont, Key_t key) -> uint32_t {
+        using T = typename C::value_type;
+        if (auto idx = keyIdx(key); keyType(key) == T::key_type && idx < size32(cont)) {
+            return idx;
+        }
+        throwWrite(key, static_cast<Type>(T::key_type));
+    }
+    auto pushArray(Key_t arrK, Type newObject) -> Key_t {
+        auto idx  = ensureWritable(arrays, arrK);
+        auto newK = addWritable(newObject); // NOTE: might resize arrays!
+        arrays[idx].add(newK);
+        return newK;
+    }
+    auto addMap(Key_t mapK, std::string_view name, Type newObject) -> Key_t {
+        auto idx = ensureWritable(maps, mapK);
+        if (const auto* key = maps[idx].find(name); key != nullptr) {
+            if (auto prevType = keyType(*key); not writable(*key) || static_cast<Type>(prevType) != newObject) {
+                throwWrite(*key, newObject);
+            }
+            return *key;
+        }
+        auto newKey = addWritable(newObject); // NOTE: might resize maps!
+        maps[idx].add(*strings.emplace(name).first, newKey);
+        return newKey;
+    }
+    auto addMap(Key_t mapK, std::string_view name, const StatisticObject& object, bool skipCheck) -> Key_t {
+        auto& map = maps[ensureWritable(maps, mapK)];
+        if (const auto* key = skipCheck ? nullptr : map.find(name); key != nullptr) {
+            POTASSCO_CHECK(object == getObject(*key), EINVAL, "unexpected object for key '%" PRIsv "'", PRI_SV(name));
+            return *key;
+        }
+        auto newKey = makeKey(KeyType::key_ext, addExternalObject(object));
+        map.add(name, newKey);
+        return newKey;
+    }
+    void setValue(Key_t valK, double value) {
+        auto idx      = ensureWritable(values, valK);
+        values[idx].d = value;
+    }
+
+    template <typename C>
+    auto addOrGetKey(const C& container, const StatisticObject& object) -> Key_t {
+        using T = typename C::value_type;
+        if (not container.empty() && object.eqTypeId(static_cast<StatisticObject>(container[0]))) {
+            auto idx = static_cast<uint32_t>(static_cast<const T*>(object.object()) - container.data());
+            return makeKey(T::key_type, idx);
+        }
+        return mapExternalObject(object);
+    }
+    auto addOrGetKey(const StatisticObject& object) -> Key_t {
+        switch (object.type()) {
+            case Type::value: return addOrGetKey(values, object);
+            case Type::array: return addOrGetKey(arrays, object);
+            case Type::map  : return addOrGetKey(maps, object);
+        }
+        POTASSCO_ASSERT_NOT_REACHED("unexpected stats type");
+    }
+    auto addExternalObject(const StatisticObject& object) -> uint32_t {
+        auto idx = size32(ext);
+        ext.push_back(object);
+        return idx;
+    }
+    auto mapExternalObject(const StatisticObject& object) -> Key_t {
+        // Eagerly assume object is not yet in the index
+        auto idx = addExternalObject(object);
+        if (auto [it, added] = index.emplace(idx); not added) {
+            // object already exists in the index
+            ext.pop_back();
+            idx = *it;
+        }
+        return makeKey(KeyType::key_ext, idx);
+    }
+    auto getChildKey(Key_t key, uint32_t idx) -> Key_t {
+        auto object = getObject(key);
+        if (object.type() == Type::array) {
+            return keyType(key) == KeyType::key_arr ? array(key).child(idx) : mapExternalObject(object[idx]);
+        }
+        throwType(Type::array, object.type());
+    }
+    auto getChildKey(Key_t key, std::string_view path) -> Key_t {
+        auto object = getObject(key);
+        auto type   = object.type();
+        auto hasKey = true;
+        if (type != Type::map) {
+            throwType(Type::map, type);
+        }
+        static constexpr auto popNext = [](std::string_view& parent,
+                                           bool              parseNum) -> std::pair<std::string_view, uint32_t> {
+            auto res = std::pair{parent.substr(0, parent.find('.')), 0u};
+            parent.remove_prefix(std::min(res.first.length() + 1, parent.length()));
+            if (int n; parseNum) {
+                auto r     = res.first;
+                res.second = static_cast<uint32_t>(Potassco::matchNum(r, nullptr, &n) && n >= 0 && r.empty() ? n : -1);
+            }
+            return res;
+        };
+        for (auto p = path; not p.empty();) {
+            auto [top, idx] = popNext(p, type == Type::array);
+            auto error      = false;
+            try {
+                if (type == Type::value || (type == Type::array && idx >= object.size())) {
+                    error = true;
+                }
+                else if (writable(key)) {
+                    key    = keyType(key) == KeyType::key_map ? map(key).child(top) : array(key).child(idx);
+                    object = getObject(key);
+                }
+                else {
+                    object = type == Type::map ? object.at(top) : object[idx];
+                    hasKey = false;
+                }
+            }
+            catch (const std::exception&) {
+                error = true;
+            }
+            if (error) {
+                path = path.substr(0, static_cast<std::size_t>((top.data() + top.size()) - path.data()));
+                throwPath(path, top);
+            }
+            type = object.type();
+        }
+        return hasKey ? key : addOrGetKey(object);
+    }
+
+    auto root() -> WritableMap& { return maps[0]; }
+    auto array(Key_t key) -> WritableArray& { return arrays.at(keyIdx(key)); }
+    auto map(Key_t key) -> WritableMap& { return maps.at(keyIdx(key)); }
+
+    using Values = PodVector_t<WritableValue>;
+    using Maps   = PodVector_t<WritableMap>;
+    using Arrays = PodVector_t<WritableArray>;
+    Objects    ext;     // external (non-writable) StatisticObjects not owned by this
+    Maps       maps;    // writable maps
+    Arrays     arrays;  // writable arrays
+    Values     values;  // writable values
+    Strings    strings; // added string keys used in writable maps
+    Object2Key index{0u, IndirectStatsHash{&ext}, IndirectStatsHash{&ext}}; // index over ext
+    SigAtomic  frozen;                                                      // whether access is currently allowed
+};
+ClaspStatistics::ClaspStatistics() : impl_(std::make_unique<Impl>()) {}
+ClaspStatistics::~ClaspStatistics() = default;
+auto ClaspStatistics::addObject(Key_t k, std::string_view name, StatisticObject o, bool skipCheck) -> Key_t {
+    return impl_->addMap(k, name, o, skipCheck);
+}
+bool ClaspStatistics::visitExternal(std::string_view name, StatsVisitor& visitor) const {
+    if (const auto* key = impl_->root().find(name); key != nullptr) {
+        visitor.visitExternalStats(impl_->getObject(*key));
+        return true;
+    }
+    return false;
+}
+void ClaspStatistics::freeze(bool b) { impl_->freeze(b); }
+auto ClaspStatistics::root() const -> Key_t { return Impl::makeKey(Impl::KeyType::key_map, 0); }
+auto ClaspStatistics::type(Key_t key) const -> Type { return impl_->getObject(key).type(); }
+auto ClaspStatistics::size(Key_t key) const -> size_t { return impl_->getObject(key).size(); }
+bool ClaspStatistics::writable(Key_t key) const { return Impl::writable(key); }
+auto ClaspStatistics::key(Key_t mapK, size_t i) const -> std::string_view {
+    return impl_->getObject(mapK).key(toU32(i));
+}
+auto ClaspStatistics::at(Key_t arrK, size_t index) const -> Key_t { return impl_->getChildKey(arrK, toU32(index)); }
+auto ClaspStatistics::get(Key_t mapK, std::string_view path) const -> Key_t { return impl_->getChildKey(mapK, path); }
+auto ClaspStatistics::push(Key_t arr, Type type) -> Key_t { return impl_->pushArray(arr, type); }
+auto ClaspStatistics::add(Key_t mapK, std::string_view name, Type type) -> Key_t {
+    return impl_->addMap(mapK, name, type);
+}
+auto ClaspStatistics::value(Key_t key) const -> double { return impl_->getObject(key).value(); }
+void ClaspStatistics::set(Key_t key, double value) { impl_->setValue(key, value); }
+bool ClaspStatistics::find(Key_t mapK, std::string_view element, Key_t* outKey) const {
+    try {
+        if (auto key = impl_->getChildKey(mapK, element); outKey) {
+            *outKey = key;
+        }
+        return true;
+    }
+    catch (const std::exception&) {
+        return false;
+    }
+}
 } // namespace Clasp

--- a/tests/cli_test.cpp
+++ b/tests/cli_test.cpp
@@ -2164,12 +2164,12 @@ TEST_CASE_METHOD(TestSink, "Output", "[cli]") {
         auto* stats = libclasp.getStats();
         out->setCallQuiet(Output::print_all);
         SECTION("step") {
-            Clasp::Test::addExternalStats(stats, "user_step");
+            Clasp::Test::addExternalStats(stats, ClaspFacade::user_step_stats);
             out->event(ClaspFacade::StepReady{libclasp.summary()});
             REQUIRE(matchOutput(expect));
         }
         SECTION("accu") {
-            Clasp::Test::addExternalStats(stats, "user_accu");
+            Clasp::Test::addExternalStats(stats, ClaspFacade::user_accu_stats);
             out->shutdown(libclasp.summary(true));
             REQUIRE(matchOutput(expect, lineOff(accuOff)));
         }

--- a/tests/facade_test.cpp
+++ b/tests/facade_test.cpp
@@ -35,6 +35,7 @@
 #endif
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
 
 #include <csignal>
 
@@ -1852,20 +1853,19 @@ TEST_CASE("Facade statistics", "[facade]") {
     config.stats           = 2;
     config.solve.numModels = 0;
     SECTION("testStatsObject") {
-        StatisticObject object;
-        REQUIRE(object.toRep() == 0);
-        REQUIRE(object.type() == StatsType::value);
-        REQUIRE(object.value() == 0.0);
-        REQUIRE(object.typeId() == 0);
-        double x = 32.0;
-        object   = StatisticObject::value(&x);
-        REQUIRE(object.toRep() != 0);
-        REQUIRE(object.type() == StatsType::value);
-        REQUIRE(object.value() == 32.0);
-        REQUIRE(object.typeId() != 0);
-        object     = StatisticObject();
-        auto other = StatisticObject::fromRep(object.toRep());
-        REQUIRE(other.type() == StatsType::value);
+        StatisticObject def;
+        REQUIRE(def.type() == StatsType::value);
+        REQUIRE(def.value() == 0.0);
+        auto x   = 32;
+        auto val = StatisticObject::value(&x);
+        REQUIRE(val.object() == &x);
+        REQUIRE_FALSE(val.eqTypeId(def));
+        REQUIRE(val.type() == StatsType::value);
+        REQUIRE(val.value() == 32.0);
+        val = StatisticObject();
+        REQUIRE(val.type() == StatsType::value);
+        REQUIRE(val.value() == 0.0);
+        REQUIRE(val.eqTypeId(def));
     }
     SECTION("testClingoStats") {
         auto& asp = libclasp.startAsp(config, true);
@@ -1905,18 +1905,39 @@ TEST_CASE("Facade statistics", "[facade]") {
         getStatsKeys(*stats, r, keys, "");
         REQUIRE_FALSE(keys.empty());
         for (const auto& key : keys) {
-            decltype(r) result;
+            auto result = r;
             REQUIRE(stats->find(r, key, &result));
             REQUIRE(result == stats->get(r, key));
             REQUIRE(stats->type(result) == StatsType::value);
         }
         REQUIRE(keys.size() == 242);
 
-        decltype(r) result;
+        auto result = r;
         REQUIRE(stats->find(r, "problem.lp", &result));
         REQUIRE(result == lp);
         REQUIRE_FALSE(stats->find(lp, "foo", nullptr));
         REQUIRE(stats->find(lp, "rules", &result));
+    }
+    SECTION("testClingoStatsMinBounds") {
+        auto& asp = libclasp.startAsp(config, true);
+        lpAdd(asp, "{x1;x2;x4}. #minimize{x1, x2, x4}. :- x1, x2, x4.");
+        libclasp.prepare();
+        libclasp.solve(std::vector{posLit(1), posLit(2), posLit(3)});
+        CHECK(libclasp.summary().unsat());
+        CHECK_FALSE(libclasp.summary().hasCosts());
+        CHECK_FALSE(libclasp.summary().hasLower());
+        CHECK(libclasp.ctx.minimizeNoCreate());
+
+        auto* stats = libclasp.getStats();
+        auto  r     = stats->root();
+        auto  costs = r;
+        REQUIRE(stats->find(r, "summary.costs", &costs));
+        REQUIRE(stats->size(costs) == 1u);
+        REQUIRE(stats->value(stats->at(costs, 0)) == std::numeric_limits<double>::infinity());
+
+        REQUIRE(stats->find(r, "summary.lower", &costs));
+        REQUIRE(stats->size(costs) == 1u);
+        REQUIRE(stats->value(stats->at(costs, 0)) == 0.0);
     }
     SECTION("testClingoStatsKeyIntegrity") {
         config.addTesterConfig()->stats = 2;
@@ -1949,6 +1970,9 @@ TEST_CASE("Facade statistics", "[facade]") {
         auto hcc0     = stats->get(stats->root(), "problem.hcc.0");
         auto hcc0Vars = stats->get(hcc0, "vars");
         REQUIRE(stats->value(hcc0Vars) != 0.0);
+        std::vector<std::string> out;
+        getStatsKeys(*stats, stats->root(), out, "");
+        REQUIRE(std::ranges::find(out, "summary.lower.0") != out.end());
         libclasp.update();
         asp.removeMinimize();
         lpAdd(asp, "x7 | x8 :- x9, not x1."
@@ -1964,6 +1988,12 @@ TEST_CASE("Facade statistics", "[facade]") {
         REQUIRE_THROWS_AS(stats->value(l0), std::logic_error);
         REQUIRE(stats->value(hcc0Vars) != 0.0);
         REQUIRE(stats->value(stats->get(stats->root(), "problem.hcc.1.vars")) != 0.0);
+        out.clear();
+        getStatsKeys(*stats, stats->root(), out, "");
+        REQUIRE(out.size() == 492);
+        REQUIRE(std::ranges::find(out, "summary.lower.0") == out.end());
+        REQUIRE(std::ranges::find(out, "summary.lower") == out.end());
+        REQUIRE(std::ranges::find(out, "summary.costs") == out.end());
     }
     SECTION("testClingoStatsWithoutStats") {
         config.stats = 0;
@@ -1979,10 +2009,76 @@ TEST_CASE("Facade statistics", "[facade]") {
         REQUIRE(stats->get(root, "solving") != root);
         REQUIRE(stats->get(root, "problem") != root);
         REQUIRE(stats->get(root, "summary") != root);
-        REQUIRE_THROWS_AS(stats->get(root, "solving.accu"), std::out_of_range);
+        REQUIRE_THROWS_AS(stats->get(root, "solving.accu"), std::logic_error);
         auto solving = stats->get(root, "solving");
         REQUIRE(stats->find(solving, "accu", nullptr) == false);
     }
+    SECTION("testClingoStatsIncStats") {
+        config.stats = 0;
+        auto& asp    = libclasp.startAsp(config, true);
+        lpAdd(asp, "{x1,x2,x3}."
+                   "x3 | x4 :- x5, not x1."
+                   "x5 :- x4, x3, not x2."
+                   "x5 :- not x1.");
+        libclasp.solve();
+        auto* stats = libclasp.getStats();
+        auto  root  = stats->root();
+        REQUIRE(stats->size(root) == 3);
+        REQUIRE(stats->get(root, "solving") != root);
+        REQUIRE(stats->get(root, "problem") != root);
+        REQUIRE(stats->get(root, "summary") != root);
+        std::vector<std::string> keys;
+        getStatsKeys(*stats, root, keys, "");
+        REQUIRE(keys.size() == 87);
+        REQUIRE(std::ranges::count_if(keys, [](const std::string& k) { return k.starts_with("summary"); }) == 13u);
+        REQUIRE(std::ranges::count_if(keys, [](const std::string& k) { return k.starts_with("solving.solvers"); }) ==
+                6u);
+        REQUIRE(std::ranges::count_if(keys, [](const std::string& k) { return k.starts_with("problem.lp."); }) == 30u);
+        REQUIRE(std::ranges::count_if(keys, [](const std::string& k) { return k.starts_with("problem.lpStep"); }) ==
+                30u);
+        REQUIRE(std::ranges::count_if(keys, [](const std::string& k) { return k.starts_with("problem.generator"); }) ==
+                8u);
+        update(config).stats = 1;
+        libclasp.update();
+        lpAdd(asp, ":- not x1.");
+        libclasp.solve();
+        REQUIRE(stats->size(root) == 4u);
+        keys.clear();
+        getStatsKeys(*stats, root, keys, "");
+        REQUIRE(keys.size() == 164);
+        REQUIRE(std::ranges::count_if(keys, [](const std::string& k) { return k.starts_with("solving.solvers"); }) ==
+                38u);
+        REQUIRE(std::ranges::count_if(
+                    keys, [](const std::string& k) { return k.starts_with("accu.solving.solvers"); }) == 38u);
+        REQUIRE(std::ranges::count_if(keys, [](const std::string& k) { return k.starts_with("accu.times"); }) == 5u);
+        REQUIRE(std::ranges::count_if(keys, [](const std::string& k) { return k.starts_with("accu.models"); }) == 2u);
+        REQUIRE(std::ranges::count_if(keys, [](const std::string& k) { return k.starts_with("solving.solver."); }) ==
+                0u);
+        REQUIRE(std::ranges::count_if(
+                    keys, [](const std::string& k) { return k.starts_with("accu.solving.solver."); }) == 0u);
+
+        update(config).stats = 2;
+        libclasp.update();
+        lpAdd(asp, ":- not x2.");
+        libclasp.solve();
+        REQUIRE(stats->size(root) == 4u);
+        keys.clear();
+        getStatsKeys(*stats, root, keys, "");
+        REQUIRE(keys.size() == 240);
+        REQUIRE(std::ranges::count_if(keys, [](const std::string& k) { return k.starts_with("solving.solver."); }) ==
+                38u);
+        REQUIRE(std::ranges::count_if(
+                    keys, [](const std::string& k) { return k.starts_with("accu.solving.solver."); }) == 38u);
+
+        libclasp.update();
+        lpAdd(asp, ":- not x3.");
+        libclasp.solve();
+        REQUIRE(stats->value(stats->get(stats->root(), "accu.solving.solver.0.choices")) >
+                stats->value(stats->get(stats->root(), "solving.solver.0.choices")));
+        REQUIRE(stats->value(stats->get(stats->root(), "accu.solving.solvers.choices")) >
+                stats->value(stats->get(stats->root(), "solving.solvers.choices")));
+    }
+
     SECTION("testClingoStatsBug") {
         config.stats = 0;
         auto& asp    = libclasp.startAsp(config, true);
@@ -2008,21 +2104,35 @@ TEST_CASE("Facade statistics", "[facade]") {
     }
     SECTION("testWritableStats") {
         ClaspStatistics stats;
-        StatsMap*       rootMap = stats.makeRoot();
-        double          v1      = 2.0;
-        rootMap->add("fixed", StatisticObject::value(&v1));
-
-        auto root = stats.root();
+        auto            root = stats.root();
         REQUIRE(stats.writable(root));
-        REQUIRE(stats.writable(stats.get(root, "fixed")) == false);
+        double v1    = 2.0;
+        auto   fixed = stats.addObject(root, "fixed", StatisticObject::value(&v1));
+        REQUIRE(stats.get(root, "fixed") == fixed);
+        REQUIRE_FALSE(stats.writable(stats.get(root, "fixed")));
+        REQUIRE(stats.addObject(root, "fixed", StatisticObject::value(&v1)) == fixed);
+        REQUIRE_THROWS_AS(stats.addObject(root, "fixed", StatisticObject()), std::logic_error);
+        auto unreachable = stats.addObject(root, "fixed", StatisticObject(), true);
+        REQUIRE(unreachable != fixed);
+        REQUIRE(stats.get(root, "fixed") == fixed);
+        REQUIRE(stats.value(unreachable) == 0.0);
 
         auto v2 = stats.add(root, "mutable", StatsType::value);
+        auto v3 = stats.add(root, "mutable2", StatsType::value);
+        auto v4 = stats.add(root, "mutable3", StatsType::value);
         REQUIRE(stats.writable(v2));
         stats.set(v2, 22.0);
         REQUIRE(stats.value(v2) == 22.0);
-        decltype(root) found;
+
+        auto found = root;
         REQUIRE(stats.find(root, "mutable", &found));
         REQUIRE(found == v2);
+
+        REQUIRE(stats.find(root, "mutable3", &found));
+        REQUIRE(found == v4);
+
+        REQUIRE(stats.find(root, "mutable2", &found));
+        REQUIRE(found == v3);
 
         auto arr = stats.add(root, "array", StatsType::array);
         REQUIRE(stats.type(arr) == StatsType::array);
@@ -2032,6 +2142,20 @@ TEST_CASE("Facade statistics", "[facade]") {
         auto mapAtArr0 = stats.push(arr, StatsType::map);
         REQUIRE(stats.type(mapAtArr0) == StatsType::map);
         REQUIRE(stats.size(arr) == 1);
+
+        stats.freeze(true);
+        REQUIRE_THROWS_AS(stats.value(fixed), std::logic_error);
+        REQUIRE(stats.value(v2) == 22.0);
+        stats.freeze(false);
+        REQUIRE(stats.value(fixed) == 2.0);
+        REQUIRE(stats.value(v2) == 22.0);
+
+        std::ignore = stats.add(mapAtArr0, "val", StatsType::value);
+        std::ignore = stats.add(mapAtArr0, "map", StatsType::map);
+        std::ignore = stats.add(mapAtArr0, "array", StatsType::array);
+        CHECK_THROWS_WITH(stats.get(mapAtArr0, "val.blub"), "bad stats access: invalid key 'blub' in path 'val.blub'");
+        CHECK_THROWS_WITH(stats.get(mapAtArr0, "map.blub"), "bad stats access: invalid key 'blub' in path 'map.blub'");
+        CHECK_THROWS_WITH(stats.get(mapAtArr0, "array.0"), "bad stats access: invalid key '0' in path 'array.0'");
     }
     SECTION("testClingoUserStats") {
         auto& asp = libclasp.startAsp(config, true);
@@ -2043,7 +2167,9 @@ TEST_CASE("Facade statistics", "[facade]") {
         auto r = stats->root();
         REQUIRE(stats->type(r) == StatsType::map);
 
-        auto u = stats->add(r, "user_step", StatsType::map);
+        auto u = stats->add(r, ClaspFacade::user_step_stats, StatsType::map);
+        REQUIRE(u == stats->add(r, ClaspFacade::user_step_stats, StatsType::map));
+        REQUIRE_THROWS_AS(stats->add(r, ClaspFacade::user_step_stats, StatsType::array), std::logic_error);
         addExternalStats(stats, u);
 
         REQUIRE(stats->type(u) == StatsType::map);
@@ -2069,7 +2195,7 @@ TEST_CASE("Facade statistics", "[facade]") {
             value = stats->get(m1, "feeding cost");
             REQUIRE(stats->value(value) == double(t + 1));
         }
-        decltype(r) total;
+        auto total = r;
         REQUIRE(stats->find(r, "user_step.deathCounter.thread.1.total", &total));
         REQUIRE(stats->type(total) == StatsType::value);
         REQUIRE(stats->value(total) == 40.0);
@@ -2118,6 +2244,31 @@ TEST_CASE("Facade statistics", "[facade]") {
         REQUIRE(vis.probs == 1);
         REQUIRE(vis.solvers == 1);
         REQUIRE(vis.user == 1);
+    }
+    SECTION("testClingoStatsProtectAgainstRace") {
+        auto& asp = libclasp.startAsp(config, true);
+        lpAdd(asp, "{x1;x2;x3}. #minimize{x1, x2}.");
+        libclasp.prepare();
+        libclasp.solve();
+        auto* stats   = libclasp.getStats();
+        auto  choices = stats->get(stats->root(), "solving.solvers.choices");
+        REQUIRE(stats->value(choices) != 0.0);
+        libclasp.update();
+        REQUIRE(stats == libclasp.getStats());
+        lpAdd(asp, "x4 | x5 :- x6, not x1."
+                   "x6 :- x4, x5, not x2."
+                   "x6 :- not x1.");
+        libclasp.prepare();
+        REQUIRE(stats == libclasp.getStats());
+        REQUIRE(stats->value(choices) == 0.0);
+        for (auto it = libclasp.solve(SolveMode::yield); it.next();) {
+            REQUIRE_THROWS_AS(libclasp.getStats(), std::logic_error);
+            CHECK_THROWS_AS(stats->value(choices), std::logic_error);
+            auto r = stats->root();
+            CHECK_THROWS_AS(stats->get(r, "solving.solvers"), std::logic_error);
+        }
+        REQUIRE(stats == libclasp.getStats());
+        REQUIRE(stats->value(choices) != 0.0);
     }
 }
 

--- a/tests/program_builder_test.cpp
+++ b/tests/program_builder_test.cpp
@@ -1011,10 +1011,10 @@ TEST_CASE("Logic program", "[asp]") {
     }
 
     SECTION("testStatisticsObject") {
-        StatisticObject stats = StatisticObject::map(&lp.stats);
+        auto stats = StatisticObject::map(&lp.stats);
         for (uint32_t i : irange(stats)) {
-            auto            k = stats.key(i);
-            StatisticObject x = stats.at(k);
+            auto k = stats.key(i);
+            auto x = stats.at(k);
             REQUIRE(x.value() == 0.0);
         }
         lpAdd(lp.start(ctx), "a :- not b.\n"
@@ -1022,6 +1022,10 @@ TEST_CASE("Logic program", "[asp]") {
         lp.endProgram();
         REQUIRE(stats.at("atoms").value() == (double) lp.stats.atoms);
         REQUIRE(stats.at("rules").value() == (double) lp.stats.rules[0].sum());
+
+        REQUIRE(stats.at("atoms").size() == 0u);
+        REQUIRE_THROWS_AS(stats.at("atoms").key(0), std::logic_error);
+        REQUIRE_THROWS_AS(stats[0], std::logic_error);
     }
     SECTION("testFactIsDefined") {
         lp.start(ctx);

--- a/tests/solver_test.cpp
+++ b/tests/solver_test.cpp
@@ -1879,27 +1879,49 @@ TEST_CASE("Solver", "[core]") {
         REQUIRE(double(10) == e.at("lemmas_deleted").value());
     }
     SECTION("testClaspStats") {
-        using Key_t = ClaspStatistics::Key_t;
         SolverStats st;
         st.enableExtended();
         st.choices           = 100;
         st.extra->learnts[1] = 5;
         st.extra->binary     = 6;
-        ClaspStatistics stats(StatisticObject::map(&st));
-        Key_t           root = stats.root();
+        ClaspStatistics stats;
+        auto            root = stats.addObject(stats.root(), "test", StatisticObject::map(&st));
         REQUIRE(stats.type(root) == Potassco::StatisticsType::map);
         REQUIRE(stats.writable(root) == false);
-        Key_t choices = stats.get(root, "choices");
+        auto choices = stats.get(root, "choices");
         REQUIRE(stats.type(choices) == Potassco::StatisticsType::value);
         REQUIRE(stats.value(choices) == (double) 100);
-        Key_t extra = stats.get(root, "extra");
+        auto extra = stats.get(root, "extra");
         REQUIRE(stats.type(extra) == Potassco::StatisticsType::map);
-        Key_t bin = stats.get(extra, "lemmas_binary");
+        auto bin = stats.get(extra, "lemmas_binary");
         REQUIRE(stats.type(bin) == Potassco::StatisticsType::value);
         REQUIRE(stats.value(bin) == (double) 6);
 
-        Key_t binByPath = stats.get(root, "extra.lemmas_binary");
+        auto binByPath = stats.get(root, "extra.lemmas_binary");
         REQUIRE(binByPath == bin);
+    }
+    SECTION("testClaspStats has stable keys") {
+        ClaspStatistics stats;
+        auto            mk = stats.add(stats.root(), "foo", Potassco::StatisticsType::map);
+        REQUIRE(stats.writable(mk));
+        auto v1 = stats.add(mk, "val1", Potassco::StatisticsType::value);
+        stats.set(v1, 123.20);
+        auto v1KeyName = stats.key(mk, 0);
+        REQUIRE(v1KeyName == "val1");
+        for (auto i : irange(10)) {
+            std::ignore = stats.add(mk, "more-" + std::to_string(i), Potassco::StatisticsType::value);
+        }
+        REQUIRE(stats.size(mk) == 11);
+        REQUIRE(stats.value(v1) == 123.20);
+        auto v1KeyAfterAdd = std::string_view{};
+        for (auto i : irange(11)) {
+            if (v1KeyAfterAdd = stats.key(mk, i); v1KeyAfterAdd == "val1") {
+                break;
+            }
+        }
+        REQUIRE(v1KeyAfterAdd == "val1");
+        CHECK(v1KeyName == v1KeyAfterAdd);
+        REQUIRE(reinterpret_cast<uintptr_t>(v1KeyAfterAdd.data()) == reinterpret_cast<uintptr_t>(v1KeyName.data()));
     }
 
     SECTION("testSplitInc") {


### PR DESCRIPTION
* ClaspStatistics assumed that it could use bits 48-63 of 64-bit pointers as tag bits for storing additional type information. While this typically works on many platforms, it breaks modern pointer authentication techniques, like e.g. ARM's  Memory Tagging Extension, or extended addressing modes, like e.g. Intel 5-level paging (LA57).

* Adjust implementation so that it no longer uses top bits of pointers. The new implementation:
  - uses 2 pointers for each StatisticObject (16- instead of 8-bytes),
  - stores StatisticObject in an additional vector, and
  - maps StatisticObject to vector indices. As a result, keys are now indices instead of direct addresses. Note: We could also use the hashmap node as key (dropping the need for the additional vector). However, this would make the interface more dangerous since we couldn't detect whether provided keys are valid.

* Freeze stats during solving to prevent race conditions/concurrent access.